### PR TITLE
Implement Moulding feature: mould generation and air channel placement

### DIFF
--- a/src/Fabolus.Core/Features/AirChannels/AirChannel.cs
+++ b/src/Fabolus.Core/Features/AirChannels/AirChannel.cs
@@ -29,7 +29,8 @@ public sealed record StraightAirChannel(
     float ConeLength,
     float TotalLength,
     float TipDiameter,
-    float CylinderDiameter) : IAirChannel
+    float CylinderDiameter,
+    float PenetrationDepth = 1.0f) : IAirChannel
 {
     public IAirChannel SetPreview(Vector3 startPoint, Vector3 direction) =>
     this with { StartPoint = startPoint };
@@ -45,20 +46,20 @@ public sealed record StraightAirChannel(
     private Result<IMesh> GeneratePoint(IGeometryEngine engine) =>
         engine.Generators.GenerateTube(new TubeParameters
         {
-            Path = new[] { StartPoint + Vector3.UnitZ * -1.0f, StartPoint + Vector3.UnitZ },
+            Path = new[] { StartPoint + Vector3.UnitZ * -PenetrationDepth, StartPoint + Vector3.UnitZ },
             Radii = new[] { TipDiameter / 2f, TipDiameter / 2f },
         });
 
     private Result<IMesh> GenerateCone(IGeometryEngine engine) =>
         engine.Generators.GenerateTube(new TubeParameters
         {
-            Path = new[] { StartPoint + Vector3.UnitZ * -1.0f, StartPoint + Vector3.UnitZ * ConeLength },
+            Path = new[] { StartPoint + Vector3.UnitZ * -PenetrationDepth, StartPoint + Vector3.UnitZ * ConeLength },
             Radii = new[] { TipDiameter / 2f, CylinderDiameter / 2f },
         });
 
     private Result<IMesh> GenerateFull(IGeometryEngine engine)
     {
-        var coneStart = StartPoint + Vector3.UnitZ * -1.0f; // penetrates a bit
+        var coneStart = StartPoint + Vector3.UnitZ * -PenetrationDepth; // brought into the mesh
         var coneEnd = StartPoint + Vector3.UnitZ * ConeLength;
         var endPoint = StartPoint + Vector3.UnitZ * TotalLength;
 
@@ -76,7 +77,8 @@ public sealed record AngledAirChannel(
     float TipLength,
     float TotalLength,
     float TipDiameter,
-    float Radius) : IAirChannel
+    float Radius,
+    float PenetrationDepth = 1.0f) : IAirChannel
 {
     public IAirChannel SetPreview(Vector3 startPoint, Vector3 direction) =>
         this with { StartPoint = startPoint, Normal = direction };
@@ -90,17 +92,17 @@ public sealed record AngledAirChannel(
 
         if (renderMode == AirChannelRenderMode.Point)
         {
-            path.Add(StartPoint + normal * -1.0f);
+            path.Add(StartPoint + normal * -PenetrationDepth);
             path.Add(StartPoint + normal * 1.0f);
         }
         else if (renderMode == AirChannelRenderMode.Cone)
         {
-            path.Add(StartPoint + normal * -1.0f);
+            path.Add(StartPoint + normal * -PenetrationDepth);
             path.Add(coneEnd);
         }
         else // Full
         {
-            path.Add(StartPoint + normal * -1.0f);
+            path.Add(StartPoint + normal * -PenetrationDepth); // brought into the mesh
             path.Add(coneEnd);
 
             var arcPoints = engine.Generators.Arc3d(Radius, coneEnd, normal, Vector3.UnitZ, 16);

--- a/src/Fabolus.Core/Features/Moulds/MouldDefinition.cs
+++ b/src/Fabolus.Core/Features/Moulds/MouldDefinition.cs
@@ -1,6 +1,6 @@
 using Fabolus.Core.Common;
-using Fabolus.Core.Geometry;
 using Fabolus.Core.Features.AirChannels;
+using Fabolus.Core.Geometry;
 
 namespace Fabolus.Core.Features.Moulds;
 
@@ -12,7 +12,7 @@ public abstract record MouldDefinition
     public abstract Result<IMesh> Generate(IGeometryEngine engine, IMesh mesh);
 }
 
-public sealed record ConvexMouldDefinition(double OffsetXY, double OffsetBottom, double OffsetTop) : MouldDefinition
+public sealed record ConvexMouldDefinition(double OffsetXY = 2.0, double OffsetBottom = 2.0, double OffsetTop = 2.0) : MouldDefinition
 {
     public override Result<IMesh> Generate(IGeometryEngine engine, IMesh mesh)
     {
@@ -36,7 +36,7 @@ public sealed record ConvexMouldDefinition(double OffsetXY, double OffsetBottom,
     }
 }
 
-public sealed record ConcaveMouldDefinition(double OffsetXY, double OffsetBottom, double OffsetTop) : MouldDefinition
+public sealed record ConcaveMouldDefinition(double OffsetXY = 2.0, double OffsetBottom = 2.0, double OffsetTop = 2.0) : MouldDefinition
 {
     public override Result<IMesh> Generate(IGeometryEngine engine, IMesh mesh)
     {
@@ -60,7 +60,7 @@ public sealed record ConcaveMouldDefinition(double OffsetXY, double OffsetBottom
     }
 }
 
-public sealed record ContouredMouldDefinition(double OffsetXY) : MouldDefinition
+public sealed record ContouredMouldDefinition(double OffsetXY = 2.0) : MouldDefinition
 {
     public override Result<IMesh> Generate(IGeometryEngine engine, IMesh mesh)
     {

--- a/src/Fabolus.Core/Features/Moulds/MouldShapeType.cs
+++ b/src/Fabolus.Core/Features/Moulds/MouldShapeType.cs
@@ -1,0 +1,8 @@
+namespace Fabolus.Core.Features.Moulds;
+
+public enum MouldShapeType
+{
+    Convex,
+    Concave,
+    Contoured
+}

--- a/src/Fabolus.Wpf/Features/Main/MainView.xaml
+++ b/src/Fabolus.Wpf/Features/Main/MainView.xaml
@@ -10,6 +10,7 @@
         xmlns:mm="clr-namespace:Fabolus.Wpf.Features.MeshManager"
         xmlns:smooth="clr-namespace:Fabolus.Wpf.Features.Smoothing"
         xmlns:rotate="clr-namespace:Fabolus.Wpf.Features.Rotatation"
+        xmlns:mould="clr-namespace:Fabolus.Wpf.Features.Moulding"
         mc:Ignorable="d"
         Title="FABOLUS" Height="720" Width="1340" MinHeight="520" MinWidth="600"
         ResizeMode="CanResizeWithGrip"
@@ -35,6 +36,10 @@
             <rotate:RotateView />
         </DataTemplate>
 
+        <DataTemplate DataType="{x:Type mould:MouldViewModel }">
+            <mould:MouldView />
+        </DataTemplate>
+        
         <Style x:Key="CaptionButton" TargetType="Button">
             <Setter Property="Width" Value="46"/>
             <Setter Property="Background" Value="Transparent"/>
@@ -172,7 +177,29 @@
                         </Button.Style>
                     </Button>
 
-                </StackPanel>
+                <Button Command="{Binding SwitchToMouldViewCommand}" IsEnabled="{Binding MeshLoaded}">
+                    <Button.Content>
+                        <StackPanel Orientation="Horizontal">
+                            <Viewbox Width="16" Height="16" Margin="0,0,7,0">
+                                <Path Data="{StaticResource Icon.Mould}"
+                                      Stroke="{DynamicResource Brush.Border.Strong}" StrokeThickness="1.2" Fill="{x:Null}"
+                                      StrokeStartLineCap="Round" StrokeEndLineCap="Round" StrokeLineJoin="Round"/>
+                            </Viewbox>
+                            <TextBlock Text="mould" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Button.Content>
+                    <Button.Style>
+                        <Style TargetType="Button" BasedOn="{StaticResource TabButton}">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding CurrentViewTitle}" Value="mould">
+                                    <Setter Property="Tag" Value="active"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Style>
+                </Button>
+                    
+            </StackPanel>
             </Border>
 
             <!-- Tools View  -->

--- a/src/Fabolus.Wpf/Features/Main/MainViewModel.cs
+++ b/src/Fabolus.Wpf/Features/Main/MainViewModel.cs
@@ -11,6 +11,7 @@ using Fabolus.Wpf.Common;
 using Fabolus.Wpf.Features.Viewport;
 using Fabolus.Wpf.Features.Smoothing;
 using Fabolus.Wpf.Features.Rotatation;
+using Fabolus.Wpf.Features.Moulding;
 
 namespace Fabolus.Wpf.Features.Main;
 public partial class MainViewModel : ObservableObject {
@@ -156,6 +157,24 @@ public partial class MainViewModel : ObservableObject {
 
         CurrentViewTitle = "rotate";
         CurrentView = new RotateViewModel(_messenger, _alertDialog, _engine);
+        SceneManager = CurrentView.SceneManager;
+
+        CurrentView.Activate(Workspace);
+    }
+
+    [RelayCommand]
+    public void SwitchToMouldView()
+    {
+        if (CurrentView is MouldViewModel)
+            return;
+
+        if (CurrentView is not null)
+        {
+            WorkspaceUpdated(CurrentView.Deactivate());
+        }
+
+        CurrentViewTitle = "mould";
+        CurrentView = new MouldViewModel(_messenger, _alertDialog, _engine);
         SceneManager = CurrentView.SceneManager;
 
         CurrentView.Activate(Workspace);

--- a/src/Fabolus.Wpf/Features/MeshManager/MeshManagerSceneManager.cs
+++ b/src/Fabolus.Wpf/Features/MeshManager/MeshManagerSceneManager.cs
@@ -51,7 +51,7 @@ internal class MeshManagerSceneManager : ISceneManager {
 
     public bool OnMouseDown(MouseDown3DEventArgs eventArgs) => false;
 
-    public bool OnMouseMove(MouseMove3DEventArgs eventArgs) => false;
+    public bool OnMouseMove(HitTestResult? hit) => false;
 
     public bool OnMouseUp(MouseUp3DEventArgs eventArgs) => false;
 

--- a/src/Fabolus.Wpf/Features/Moulding/ChannelsControl.xaml
+++ b/src/Fabolus.Wpf/Features/Moulding/ChannelsControl.xaml
@@ -4,7 +4,6 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Fabolus.Wpf.Features.Moulding"
-             xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
              mc:Ignorable="d"
              d:DesignHeight="620" d:DesignWidth="260"
              Background="Transparent">
@@ -82,44 +81,6 @@
             </Setter>
         </Style>
 
-        <!-- Placed-channel list row -->
-        <DataTemplate x:Key="ChannelRowTemplate">
-            <Grid Margin="9,8">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-
-                <!-- index badge -->
-                <Border Grid.Column="0" Width="20" Height="20" CornerRadius="5"
-                        Background="{DynamicResource Brush.Accent}" VerticalAlignment="Center">
-                    <TextBlock Text="{Binding Index}" Foreground="{DynamicResource Brush.Text.OnAccent}"
-                               FontFamily="{StaticResource Font.Mono}" FontSize="10" FontWeight="SemiBold"
-                               HorizontalAlignment="Center" VerticalAlignment="Center" />
-                </Border>
-
-                <!-- name + summary -->
-                <StackPanel Grid.Column="1" Margin="9,0" VerticalAlignment="Center">
-                    <TextBlock Text="{Binding Name}"
-                               FontFamily="{StaticResource Font.Sans}" FontSize="12.5" FontWeight="SemiBold"
-                               Foreground="{DynamicResource Brush.Text.Primary}" />
-                    <TextBlock Text="{Binding Summary}"
-                               FontFamily="{StaticResource Font.Mono}" FontSize="10"
-                               Foreground="{DynamicResource Brush.Text.Muted}" />
-                </StackPanel>
-
-                <!-- type chip -->
-                <Border Grid.Column="2" CornerRadius="10" Background="{DynamicResource Brush.Surface}"
-                        BorderBrush="{DynamicResource Brush.Border}" BorderThickness="1"
-                        Padding="7,3" VerticalAlignment="Center">
-                    <TextBlock Text="{Binding TypeLabel}"
-                               FontFamily="{StaticResource Font.Sans}" FontSize="9.5" FontWeight="SemiBold"
-                               Foreground="{DynamicResource Brush.Text.Secondary}" />
-                </Border>
-            </Grid>
-        </DataTemplate>
-
     </UserControl.Resources>
     
     <!-- ============================================================ -->
@@ -144,7 +105,7 @@
                                            Foreground="{DynamicResource Brush.Text.Primary}" />
                 <Border Grid.Column="2" Style="{StaticResource Tag.Accent}" CornerRadius="10" Padding="7,3"
                                         VerticalAlignment="Center">
-                    <TextBlock Text="{Binding Channels.Count}"
+                    <TextBlock Text="{Binding ChannelCount}"
                                                FontFamily="{StaticResource Font.Mono}" FontSize="10" FontWeight="SemiBold"
                                                Foreground="{DynamicResource Brush.Accent.Pressed}" />
                 </Border>
@@ -154,19 +115,8 @@
         <!-- Channel editing body -->
         <StackPanel Margin="16,4,16,18">
 
-            <!-- has-channels editing block -->
+            <!-- placement / selection settings -->
             <StackPanel>
-                <StackPanel.Style>
-                    <Style TargetType="StackPanel">
-                        <Setter Property="Visibility" Value="Visible" />
-                        <Style.Triggers>
-                            <DataTrigger Binding="{Binding HasChannels}" Value="False">
-                                <Setter Property="Visibility" Value="Collapsed" />
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </StackPanel.Style>
-
                 <!-- channel type selector -->
                 <TextBlock Text="CHANNEL TYPE" Style="{StaticResource Text.SectionLabel}" Margin="0,0,0,8" />
                 <UniformGrid Columns="3" Margin="-3,0,-3,8">
@@ -187,14 +137,16 @@
                                                  Command="{Binding SetChannelTypeCommand}" CommandParameter="Path" />
                 </UniformGrid>
                 <TextBlock Text="{Binding ChannelTypeDescription}" Style="{StaticResource FieldHint}"
-                                           Margin="0,0,0,16" />
+                                           Margin="0,0,0,4" />
+                <TextBlock Text="Click a point on the mesh to place a channel with the settings below, or click an existing channel to select and edit it."
+                                           Style="{StaticResource FieldHint}" Margin="0,0,0,16" />
 
-                <!-- parameters for the selected / next channel -->
+                <!-- parameters for the next channel -->
                 <Grid Margin="0,0,0,8">
                     <TextBlock Text="PARAMETERS" Style="{StaticResource Text.SectionLabel}"
                                                HorizontalAlignment="Left" VerticalAlignment="Center" />
                     <Border Style="{StaticResource Tag.Accent}" HorizontalAlignment="Right">
-                        <TextBlock Text="{Binding SelectedChannel.Name}"
+                        <TextBlock Text="{Binding ChannelType}"
                                                    FontFamily="{StaticResource Font.Sans}" FontSize="10.5" FontWeight="SemiBold"
                                                    Foreground="{DynamicResource Brush.Accent.Pressed}" />
                     </Border>
@@ -219,7 +171,7 @@
                         <TextBlock Text="{Binding TipLength, StringFormat={}{0:F0} mm}"
                                                    Style="{StaticResource Text.Value}" HorizontalAlignment="Right" />
                     </Grid>
-                    <Slider Minimum="0" Maximum="20" Style="{StaticResource Slider.Steel}"
+                    <Slider Minimum="0" Maximum="8" Style="{StaticResource Slider.Steel}"
                                             Value="{Binding TipLength, Mode=TwoWay}"
                                             SmallChange="1" LargeChange="2" VerticalAlignment="Center" />
                 </StackPanel>
@@ -228,13 +180,13 @@
                 <StackPanel Margin="0,0,0,13">
                     <Grid Margin="0,0,0,4">
                         <TextBlock Text="Tip depth" Style="{StaticResource FieldLabel}" HorizontalAlignment="Left" />
-                        <TextBlock Text="{Binding TipDepth, StringFormat={}{0:F0} mm}"
+                        <TextBlock Text="{Binding TipDepth, StringFormat={}{0:F1} mm}"
                                                    Style="{StaticResource Text.Value}" HorizontalAlignment="Right" />
                     </Grid>
-                    <Slider Minimum="0" Maximum="12" Style="{StaticResource Slider.Steel}"
+                    <Slider Minimum="0" Maximum="2" Style="{StaticResource Slider.Steel}"
                                             Value="{Binding TipDepth, Mode=TwoWay}"
-                                            SmallChange="1" LargeChange="2" VerticalAlignment="Center" />
-                    <TextBlock Text="How far past the start point the tip sinks into the mesh."
+                                            SmallChange="0.1" LargeChange="0.5" VerticalAlignment="Center" />
+                    <TextBlock Text="How far the start point is brought into the mesh, against the surface normal."
                                                Style="{StaticResource FieldHint}" Margin="0,6,0,0" />
                 </StackPanel>
 

--- a/src/Fabolus.Wpf/Features/Moulding/ChannelsControl.xaml
+++ b/src/Fabolus.Wpf/Features/Moulding/ChannelsControl.xaml
@@ -1,0 +1,282 @@
+﻿<UserControl x:Class="Fabolus.Wpf.Features.Moulding.ChannelsControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Fabolus.Wpf.Features.Moulding"
+             xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+             mc:Ignorable="d"
+             d:DesignHeight="620" d:DesignWidth="260"
+             Background="Transparent">
+    
+    <UserControl.Resources>
+        <!-- Channel-type stroke icons (16x16, drawn with Stroke) -->
+        <Geometry x:Key="Icon.ChannelStraight">M8 14 L8 3 M5 6 L8 3 L11 6</Geometry>
+        <Geometry x:Key="Icon.ChannelAngled">M4 14 L8 8.5 L8 3 M5.6 4.6 L8 2.6 L10.4 4.6</Geometry>
+        <Geometry x:Key="Icon.ChannelPath">M2.5 11 C5.1 11 4.9 6 7.5 6 S10.1 11 13 11</Geometry>
+        <Geometry x:Key="Icon.Trash">M3 4.5 L13 4.5 M6.5 4.5 L6.5 3.2 L9.5 3.2 L9.5 4.5 M4.5 4.5 L5 12.8 a1 1 0 0 0 1 0.9 L10 13.7 a1 1 0 0 0 1 -0.9 L11.5 4.5</Geometry>
+
+        <!-- Field caption above each control -->
+        <Style x:Key="FieldLabel" TargetType="TextBlock">
+            <Setter Property="FontFamily" Value="{StaticResource Font.Sans}" />
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="FontWeight" Value="Medium" />
+            <Setter Property="Foreground" Value="{DynamicResource Brush.Text.Secondary}" />
+        </Style>
+
+        <!-- Helper caption (sub-label under a control) -->
+        <Style x:Key="FieldHint" TargetType="TextBlock">
+            <Setter Property="FontFamily" Value="{StaticResource Font.Sans}" />
+            <Setter Property="FontSize" Value="10.5" />
+            <Setter Property="Foreground" Value="{DynamicResource Brush.Text.Muted}" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+        </Style>
+
+        <!-- Accordion section header: icon + title (+ optional trailing content) -->
+        <Style x:Key="SectionExpander" TargetType="Expander">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="{DynamicResource Brush.Divider}" />
+            <Setter Property="BorderThickness" Value="0,0,0,1" />
+            <Setter Property="Padding" Value="0" />
+        </Style>
+
+        <!-- One channel-type segment: bordered card, icon over label, cyan when checked.
+             Geometry is passed through the RadioButton's Tag. -->
+        <Style x:Key="TypeSegment" TargetType="RadioButton">
+            <Setter Property="Foreground" Value="{DynamicResource Brush.Text.Secondary}" />
+            <Setter Property="FontFamily" Value="{StaticResource Font.Sans}" />
+            <Setter Property="FontSize" Value="10.5" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="SnapsToDevicePixels" Value="True" />
+            <Setter Property="Margin" Value="3,0" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="RadioButton">
+                        <Border x:Name="seg" CornerRadius="8" Padding="0,10,0,8"
+                                Background="{DynamicResource Brush.Card}"
+                                BorderBrush="{DynamicResource Brush.Border}" BorderThickness="1"
+                                TextElement.Foreground="{TemplateBinding Foreground}">
+                            <StackPanel HorizontalAlignment="Center">
+                                <Viewbox Width="17" Height="17" Margin="0,0,0,6">
+                                    <Path Data="{TemplateBinding Tag}"
+                                          Stroke="{Binding Foreground, RelativeSource={RelativeSource TemplatedParent}}"
+                                          StrokeThickness="1.6" Fill="{x:Null}"
+                                          StrokeStartLineCap="Round" StrokeEndLineCap="Round" StrokeLineJoin="Round" />
+                                </Viewbox>
+                                <ContentPresenter HorizontalAlignment="Center" />
+                            </StackPanel>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="seg" Property="BorderBrush" Value="{DynamicResource Brush.Border.Strong}" />
+                            </Trigger>
+                            <Trigger Property="IsChecked" Value="True">
+                                <Setter TargetName="seg" Property="Background" Value="{DynamicResource Brush.Accent}" />
+                                <Setter TargetName="seg" Property="BorderBrush" Value="{DynamicResource Brush.Accent}" />
+                                <Setter Property="Foreground" Value="{DynamicResource Brush.Text.OnAccent}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <!-- Placed-channel list row -->
+        <DataTemplate x:Key="ChannelRowTemplate">
+            <Grid Margin="9,8">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <!-- index badge -->
+                <Border Grid.Column="0" Width="20" Height="20" CornerRadius="5"
+                        Background="{DynamicResource Brush.Accent}" VerticalAlignment="Center">
+                    <TextBlock Text="{Binding Index}" Foreground="{DynamicResource Brush.Text.OnAccent}"
+                               FontFamily="{StaticResource Font.Mono}" FontSize="10" FontWeight="SemiBold"
+                               HorizontalAlignment="Center" VerticalAlignment="Center" />
+                </Border>
+
+                <!-- name + summary -->
+                <StackPanel Grid.Column="1" Margin="9,0" VerticalAlignment="Center">
+                    <TextBlock Text="{Binding Name}"
+                               FontFamily="{StaticResource Font.Sans}" FontSize="12.5" FontWeight="SemiBold"
+                               Foreground="{DynamicResource Brush.Text.Primary}" />
+                    <TextBlock Text="{Binding Summary}"
+                               FontFamily="{StaticResource Font.Mono}" FontSize="10"
+                               Foreground="{DynamicResource Brush.Text.Muted}" />
+                </StackPanel>
+
+                <!-- type chip -->
+                <Border Grid.Column="2" CornerRadius="10" Background="{DynamicResource Brush.Surface}"
+                        BorderBrush="{DynamicResource Brush.Border}" BorderThickness="1"
+                        Padding="7,3" VerticalAlignment="Center">
+                    <TextBlock Text="{Binding TypeLabel}"
+                               FontFamily="{StaticResource Font.Sans}" FontSize="9.5" FontWeight="SemiBold"
+                               Foreground="{DynamicResource Brush.Text.Secondary}" />
+                </Border>
+            </Grid>
+        </DataTemplate>
+
+    </UserControl.Resources>
+    
+    <!-- ============================================================ -->
+    <!--  AIR CHANNELS                                                -->
+    <!-- ============================================================ -->
+    <Expander Style="{StaticResource SectionExpander}"
+                              IsExpanded="{Binding IsChannelsExpanded, Mode=TwoWay}">
+        <Expander.Header>
+            <Grid Height="46" VerticalAlignment="Center">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <Viewbox Grid.Column="0" Width="16" Height="16" Margin="0,0,10,0">
+                    <Path Data="{StaticResource Icon.Channels}"
+                                          Stroke="{DynamicResource Brush.Accent.Pressed}" StrokeThickness="1.6" Fill="{x:Null}"
+                                          StrokeStartLineCap="Round" StrokeEndLineCap="Round" StrokeLineJoin="Round" />
+                </Viewbox>
+                <TextBlock Grid.Column="1" Text="Air Channels" VerticalAlignment="Center"
+                                           FontFamily="{StaticResource Font.Sans}" FontSize="14" FontWeight="SemiBold"
+                                           Foreground="{DynamicResource Brush.Text.Primary}" />
+                <Border Grid.Column="2" Style="{StaticResource Tag.Accent}" CornerRadius="10" Padding="7,3"
+                                        VerticalAlignment="Center">
+                    <TextBlock Text="{Binding Channels.Count}"
+                                               FontFamily="{StaticResource Font.Mono}" FontSize="10" FontWeight="SemiBold"
+                                               Foreground="{DynamicResource Brush.Accent.Pressed}" />
+                </Border>
+            </Grid>
+        </Expander.Header>
+
+        <!-- Channel editing body -->
+        <StackPanel Margin="16,4,16,18">
+
+            <!-- has-channels editing block -->
+            <StackPanel>
+                <StackPanel.Style>
+                    <Style TargetType="StackPanel">
+                        <Setter Property="Visibility" Value="Visible" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding HasChannels}" Value="False">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </StackPanel.Style>
+
+                <!-- channel type selector -->
+                <TextBlock Text="CHANNEL TYPE" Style="{StaticResource Text.SectionLabel}" Margin="0,0,0,8" />
+                <UniformGrid Columns="3" Margin="-3,0,-3,8">
+                    <RadioButton Content="Straight" GroupName="ChannelType"
+                                                 Style="{StaticResource TypeSegment}"
+                                                 Tag="{StaticResource Icon.ChannelStraight}"
+                                                 IsChecked="{Binding IsStraightType, Mode=OneWay}"
+                                                 Command="{Binding SetChannelTypeCommand}" CommandParameter="Straight" />
+                    <RadioButton Content="Angled" GroupName="ChannelType"
+                                                 Style="{StaticResource TypeSegment}"
+                                                 Tag="{StaticResource Icon.ChannelAngled}"
+                                                 IsChecked="{Binding IsAngledType, Mode=OneWay}"
+                                                 Command="{Binding SetChannelTypeCommand}" CommandParameter="Angled" />
+                    <RadioButton Content="Path" GroupName="ChannelType"
+                                                 Style="{StaticResource TypeSegment}"
+                                                 Tag="{StaticResource Icon.ChannelPath}"
+                                                 IsChecked="{Binding IsPathType, Mode=OneWay}"
+                                                 Command="{Binding SetChannelTypeCommand}" CommandParameter="Path" />
+                </UniformGrid>
+                <TextBlock Text="{Binding ChannelTypeDescription}" Style="{StaticResource FieldHint}"
+                                           Margin="0,0,0,16" />
+
+                <!-- parameters for the selected / next channel -->
+                <Grid Margin="0,0,0,8">
+                    <TextBlock Text="PARAMETERS" Style="{StaticResource Text.SectionLabel}"
+                                               HorizontalAlignment="Left" VerticalAlignment="Center" />
+                    <Border Style="{StaticResource Tag.Accent}" HorizontalAlignment="Right">
+                        <TextBlock Text="{Binding SelectedChannel.Name}"
+                                                   FontFamily="{StaticResource Font.Sans}" FontSize="10.5" FontWeight="SemiBold"
+                                                   Foreground="{DynamicResource Brush.Accent.Pressed}" />
+                    </Border>
+                </Grid>
+
+                <!-- Tip diameter -->
+                <StackPanel Margin="0,0,0,13">
+                    <Grid Margin="0,0,0,4">
+                        <TextBlock Text="Tip diameter" Style="{StaticResource FieldLabel}" HorizontalAlignment="Left" />
+                        <TextBlock Text="{Binding TipDiameter, StringFormat={}{0:F1} mm}"
+                                                   Style="{StaticResource Text.Value}" HorizontalAlignment="Right" />
+                    </Grid>
+                    <Slider Minimum="1" Maximum="12" Style="{StaticResource Slider.Steel}"
+                                            Value="{Binding TipDiameter, Mode=TwoWay}"
+                                            SmallChange="0.1" LargeChange="1" VerticalAlignment="Center" />
+                </StackPanel>
+
+                <!-- Tip length -->
+                <StackPanel Margin="0,0,0,13">
+                    <Grid Margin="0,0,0,4">
+                        <TextBlock Text="Tip length" Style="{StaticResource FieldLabel}" HorizontalAlignment="Left" />
+                        <TextBlock Text="{Binding TipLength, StringFormat={}{0:F0} mm}"
+                                                   Style="{StaticResource Text.Value}" HorizontalAlignment="Right" />
+                    </Grid>
+                    <Slider Minimum="0" Maximum="20" Style="{StaticResource Slider.Steel}"
+                                            Value="{Binding TipLength, Mode=TwoWay}"
+                                            SmallChange="1" LargeChange="2" VerticalAlignment="Center" />
+                </StackPanel>
+
+                <!-- Tip depth -->
+                <StackPanel Margin="0,0,0,13">
+                    <Grid Margin="0,0,0,4">
+                        <TextBlock Text="Tip depth" Style="{StaticResource FieldLabel}" HorizontalAlignment="Left" />
+                        <TextBlock Text="{Binding TipDepth, StringFormat={}{0:F0} mm}"
+                                                   Style="{StaticResource Text.Value}" HorizontalAlignment="Right" />
+                    </Grid>
+                    <Slider Minimum="0" Maximum="12" Style="{StaticResource Slider.Steel}"
+                                            Value="{Binding TipDepth, Mode=TwoWay}"
+                                            SmallChange="1" LargeChange="2" VerticalAlignment="Center" />
+                    <TextBlock Text="How far past the start point the tip sinks into the mesh."
+                                               Style="{StaticResource FieldHint}" Margin="0,6,0,0" />
+                </StackPanel>
+
+                <!-- Channel diameter -->
+                <StackPanel Margin="0,0,0,16">
+                    <Grid Margin="0,0,0,4">
+                        <TextBlock Text="Channel diameter" Style="{StaticResource FieldLabel}" HorizontalAlignment="Left" />
+                        <TextBlock Text="{Binding ChannelDiameter, StringFormat={}{0:F1} mm}"
+                                                   Style="{StaticResource Text.Value}" HorizontalAlignment="Right" />
+                    </Grid>
+                    <Slider Minimum="1" Maximum="12" Style="{StaticResource Slider.Steel}"
+                                            Value="{Binding ChannelDiameter, Mode=TwoWay}"
+                                            SmallChange="0.1" LargeChange="1" VerticalAlignment="Center" />
+                </StackPanel>
+
+                <!-- delete / clear actions -->
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Button Grid.Column="0" Command="{Binding DeleteSelectedChannelCommand}"
+                                            Style="{StaticResource Button.Secondary}" Margin="0,0,8,0"
+                                            Foreground="{DynamicResource Brush.Danger}"
+                                            BorderBrush="{DynamicResource Brush.Danger}"
+                                            HorizontalAlignment="Stretch">
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <Viewbox Width="14" Height="14" Margin="0,0,7,0">
+                                <Path Data="{StaticResource Icon.Trash}"
+                                                      Stroke="{DynamicResource Brush.Danger}" StrokeThickness="1.5" Fill="{x:Null}"
+                                                      StrokeStartLineCap="Round" StrokeEndLineCap="Round" StrokeLineJoin="Round" />
+                            </Viewbox>
+                            <TextBlock Text="Delete" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Button>
+                    <Button Grid.Column="1" Command="{Binding ClearChannelsCommand}"
+                                            Content="Clear all" Style="{StaticResource Button.Secondary}"
+                                            Padding="14,0" />
+                </Grid>
+            </StackPanel>
+
+
+        </StackPanel>
+    </Expander>
+</UserControl>

--- a/src/Fabolus.Wpf/Features/Moulding/ChannelsControl.xaml.cs
+++ b/src/Fabolus.Wpf/Features/Moulding/ChannelsControl.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace Fabolus.Wpf.Features.Moulding
+{
+    /// <summary>
+    /// Interaction logic for ChannelsControl.xaml
+    /// </summary>
+    public partial class ChannelsControl : UserControl
+    {
+        public ChannelsControl()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Fabolus.Wpf/Features/Moulding/MouldControl.xaml
+++ b/src/Fabolus.Wpf/Features/Moulding/MouldControl.xaml
@@ -4,7 +4,6 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Fabolus.Wpf.Features.Moulding"
-             xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
              Background="Transparent">
     <UserControl.Resources>
 
@@ -54,14 +53,19 @@
                     <TextBlock Grid.Column="1" Text="Mould" VerticalAlignment="Center"
                                 FontFamily="{StaticResource Font.Sans}" FontSize="14" FontWeight="SemiBold"
                                 Foreground="{DynamicResource Brush.Text.Primary}" />
-                    <TextBlock Grid.Column="2" Text="2-part" VerticalAlignment="Center"
-                                FontFamily="{StaticResource Font.Mono}" FontSize="10"
-                                Foreground="{DynamicResource Brush.Text.Muted}" />
                 </Grid>
             </Expander.Header>
 
             <!-- Mould editing body -->
             <StackPanel Margin="16,4,16,18">
+
+                <!-- Mould shape -->
+                <StackPanel Margin="0,0,0,15">
+                    <TextBlock Text="Shape" Style="{StaticResource FieldLabel}" Margin="0,0,0,7" />
+                    <ComboBox ItemsSource="{Binding MouldShapeTypes}"
+                                SelectedItem="{Binding SelectedMouldType, Mode=TwoWay}"
+                                FontFamily="{StaticResource Font.Sans}" FontSize="13" Height="36" />
+                </StackPanel>
 
                 <!-- Wall thickness -->
                 <StackPanel Margin="0,0,0,15">
@@ -85,37 +89,6 @@
                     <Slider Minimum="0" Maximum="30" Style="{StaticResource Slider.Steel}"
                             Value="{Binding BaseHeight, Mode=TwoWay}"
                             SmallChange="1" LargeChange="5" VerticalAlignment="Center" />
-                </StackPanel>
-
-                <!-- Draft angle -->
-                <StackPanel Margin="0,0,0,15">
-                    <Grid Margin="0,0,0,4">
-                        <TextBlock Text="Draft angle" Style="{StaticResource FieldLabel}" HorizontalAlignment="Left" />
-                        <TextBlock Text="{Binding DraftAngle, StringFormat={}{0:F0}°}"
-                                    Style="{StaticResource Text.Value}" HorizontalAlignment="Right" />
-                    </Grid>
-                    <Slider Minimum="0" Maximum="10" Style="{StaticResource Slider.Steel}"
-                            Value="{Binding DraftAngle, Mode=TwoWay}"
-                            SmallChange="1" LargeChange="2" VerticalAlignment="Center" />
-                </StackPanel>
-
-                <!-- Split into 2 parts -->
-                <Grid Margin="0,0,0,15">
-                    <TextBlock Text="Split into 2 parts"
-                                FontFamily="{StaticResource Font.Sans}" FontSize="13" FontWeight="Medium"
-                                Foreground="{DynamicResource Brush.Text.Primary}"
-                                VerticalAlignment="Center" HorizontalAlignment="Left" />
-                    <mah:ToggleSwitch IsOn="{Binding SplitMould, Mode=TwoWay}"
-                                        HorizontalAlignment="Right" VerticalAlignment="Center"
-                                        OnContent="" OffContent="" />
-                </Grid>
-
-                <!-- Resolution -->
-                <StackPanel>
-                    <TextBlock Text="Resolution" Style="{StaticResource FieldLabel}" Margin="0,0,0,7" />
-                    <ComboBox ItemsSource="{Binding Resolutions}"
-                                SelectedItem="{Binding SelectedResolution, Mode=TwoWay}"
-                                FontFamily="{StaticResource Font.Sans}" FontSize="13" Height="36" />
                 </StackPanel>
 
             </StackPanel>

--- a/src/Fabolus.Wpf/Features/Moulding/MouldControl.xaml
+++ b/src/Fabolus.Wpf/Features/Moulding/MouldControl.xaml
@@ -1,0 +1,124 @@
+﻿<UserControl x:Class="Fabolus.Wpf.Features.Moulding.MouldControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Fabolus.Wpf.Features.Moulding"
+             xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+             Background="Transparent">
+    <UserControl.Resources>
+
+        <!-- Field caption above each control -->
+        <Style x:Key="FieldLabel" TargetType="TextBlock">
+            <Setter Property="FontFamily" Value="{StaticResource Font.Sans}" />
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="FontWeight" Value="Medium" />
+            <Setter Property="Foreground" Value="{DynamicResource Brush.Text.Secondary}" />
+        </Style>
+
+        <!-- Helper caption (sub-label under a control) -->
+        <Style x:Key="FieldHint" TargetType="TextBlock">
+            <Setter Property="FontFamily" Value="{StaticResource Font.Sans}" />
+            <Setter Property="FontSize" Value="10.5" />
+            <Setter Property="Foreground" Value="{DynamicResource Brush.Text.Muted}" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+        </Style>
+
+        <!-- Accordion section header: icon + title (+ optional trailing content) -->
+        <Style x:Key="SectionExpander" TargetType="Expander">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="{DynamicResource Brush.Divider}" />
+            <Setter Property="BorderThickness" Value="0,0,0,1" />
+            <Setter Property="Padding" Value="0" />
+        </Style>
+
+    </UserControl.Resources>
+
+        <!-- ============================================================ -->
+        <!--  MOULD                                                       -->
+        <!-- ============================================================ -->
+        <Expander Style="{StaticResource SectionExpander}"
+                    IsExpanded="{Binding IsMouldExpanded, Mode=TwoWay}">
+            <Expander.Header>
+                <Grid Height="46" VerticalAlignment="Center">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Viewbox Grid.Column="0" Width="16" Height="16" Margin="0,0,10,0">
+                        <Path Data="{StaticResource Icon.Mould}"
+                                Stroke="{DynamicResource Brush.Accent.Pressed}" StrokeThickness="1.5" Fill="{x:Null}"
+                                StrokeStartLineCap="Round" StrokeEndLineCap="Round" StrokeLineJoin="Round" />
+                    </Viewbox>
+                    <TextBlock Grid.Column="1" Text="Mould" VerticalAlignment="Center"
+                                FontFamily="{StaticResource Font.Sans}" FontSize="14" FontWeight="SemiBold"
+                                Foreground="{DynamicResource Brush.Text.Primary}" />
+                    <TextBlock Grid.Column="2" Text="2-part" VerticalAlignment="Center"
+                                FontFamily="{StaticResource Font.Mono}" FontSize="10"
+                                Foreground="{DynamicResource Brush.Text.Muted}" />
+                </Grid>
+            </Expander.Header>
+
+            <!-- Mould editing body -->
+            <StackPanel Margin="16,4,16,18">
+
+                <!-- Wall thickness -->
+                <StackPanel Margin="0,0,0,15">
+                    <Grid Margin="0,0,0,4">
+                        <TextBlock Text="Wall thickness" Style="{StaticResource FieldLabel}" HorizontalAlignment="Left" />
+                        <TextBlock Text="{Binding WallThickness, StringFormat={}{0:F1} mm}"
+                                    Style="{StaticResource Text.Value}" HorizontalAlignment="Right" />
+                    </Grid>
+                    <Slider Minimum="1" Maximum="10" Style="{StaticResource Slider.Steel}"
+                            Value="{Binding WallThickness, Mode=TwoWay}"
+                            SmallChange="0.1" LargeChange="1" VerticalAlignment="Center" />
+                </StackPanel>
+
+                <!-- Base height -->
+                <StackPanel Margin="0,0,0,15">
+                    <Grid Margin="0,0,0,4">
+                        <TextBlock Text="Base height" Style="{StaticResource FieldLabel}" HorizontalAlignment="Left" />
+                        <TextBlock Text="{Binding BaseHeight, StringFormat={}{0:F0} mm}"
+                                    Style="{StaticResource Text.Value}" HorizontalAlignment="Right" />
+                    </Grid>
+                    <Slider Minimum="0" Maximum="30" Style="{StaticResource Slider.Steel}"
+                            Value="{Binding BaseHeight, Mode=TwoWay}"
+                            SmallChange="1" LargeChange="5" VerticalAlignment="Center" />
+                </StackPanel>
+
+                <!-- Draft angle -->
+                <StackPanel Margin="0,0,0,15">
+                    <Grid Margin="0,0,0,4">
+                        <TextBlock Text="Draft angle" Style="{StaticResource FieldLabel}" HorizontalAlignment="Left" />
+                        <TextBlock Text="{Binding DraftAngle, StringFormat={}{0:F0}°}"
+                                    Style="{StaticResource Text.Value}" HorizontalAlignment="Right" />
+                    </Grid>
+                    <Slider Minimum="0" Maximum="10" Style="{StaticResource Slider.Steel}"
+                            Value="{Binding DraftAngle, Mode=TwoWay}"
+                            SmallChange="1" LargeChange="2" VerticalAlignment="Center" />
+                </StackPanel>
+
+                <!-- Split into 2 parts -->
+                <Grid Margin="0,0,0,15">
+                    <TextBlock Text="Split into 2 parts"
+                                FontFamily="{StaticResource Font.Sans}" FontSize="13" FontWeight="Medium"
+                                Foreground="{DynamicResource Brush.Text.Primary}"
+                                VerticalAlignment="Center" HorizontalAlignment="Left" />
+                    <mah:ToggleSwitch IsOn="{Binding SplitMould, Mode=TwoWay}"
+                                        HorizontalAlignment="Right" VerticalAlignment="Center"
+                                        OnContent="" OffContent="" />
+                </Grid>
+
+                <!-- Resolution -->
+                <StackPanel>
+                    <TextBlock Text="Resolution" Style="{StaticResource FieldLabel}" Margin="0,0,0,7" />
+                    <ComboBox ItemsSource="{Binding Resolutions}"
+                                SelectedItem="{Binding SelectedResolution, Mode=TwoWay}"
+                                FontFamily="{StaticResource Font.Sans}" FontSize="13" Height="36" />
+                </StackPanel>
+
+            </StackPanel>
+        </Expander>
+
+</UserControl>

--- a/src/Fabolus.Wpf/Features/Moulding/MouldControl.xaml.cs
+++ b/src/Fabolus.Wpf/Features/Moulding/MouldControl.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace Fabolus.Wpf.Features.Moulding
+{
+    /// <summary>
+    /// Interaction logic for MouldControl.xaml
+    /// </summary>
+    public partial class MouldControl : UserControl
+    {
+        public MouldControl()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Fabolus.Wpf/Features/Moulding/MouldSceneManager.cs
+++ b/src/Fabolus.Wpf/Features/Moulding/MouldSceneManager.cs
@@ -1,69 +1,299 @@
-﻿using Fabolus.Core.Common;
+﻿using System.Numerics;
+using System.Windows;
+using System.Windows.Input;
+using Fabolus.Core.Common;
 using Fabolus.Core.Features.AirChannels;
 using Fabolus.Core.Features.Moulds;
 using Fabolus.Core.Geometry;
+using Fabolus.Wpf.Common.Mesh;
 using Fabolus.Wpf.Features.Viewport;
 using HelixToolkit.Wpf.SharpDX;
-using System.Numerics;
-using System.Windows.Input;
 
 namespace Fabolus.Wpf.Features.Moulding;
 
 public class MouldSceneManager : ISceneManager
 {
     private readonly IGeometryEngine _engine;
+    private readonly Element3D _grid;
+
+    private readonly Material _targetSkin = DiffuseMaterials.Gray;
+
+    // The mould is only ever shown as a live preview before generation.
+    private readonly Material _mouldSkin = DiffuseMaterials.Ruby;
+
+    private readonly Material _channelSkin = DiffuseMaterials.Emerald;
+    private readonly Material _selectedChannelSkin = DiffuseMaterials.Pearl;
+    private readonly Material _previewChannelSkin = DiffuseMaterials.Pearl;
 
     private Workspace Workspace { get; set; }
-    private IReadOnlyList<IAirChannel> Channels { get; set; } = [];
+    private IMesh TargetMesh { get; set; }
+    private IReadOnlyList<AirChannelModel> Channels { get; set; } = [];
     private IAirChannel PreviewChannel { get; set; }
-    private MouldDefinition MouldDefinition { get; set; }
+
+    private Guid _targetMeshId = Guid.Empty;
+    private Guid _previewChannelId = Guid.Empty;
+    private Guid _selectedChannelId = Guid.Empty;
+
+    private MeshGeometryModel3D _mouldModel;
+    private bool _mouldHiddenForHover;
+    private bool _mouseOverTarget;
+
+    private readonly Dictionary<Guid, Guid> _channelVisualToModelId = [];
+    private readonly Dictionary<Guid, Guid> _channelModelToVisualId = [];
 
     public event Action<Element3D> VisualAddedOrUpdated;
     public event Action<Guid> VisualRemovedById;
     public event Action VisualsCleared;
 
+    public event Action<Vector3, Vector3> ChannelPlaced;
+    public event Action<Guid> ChannelSelected;
+    public event Action<Vector3, Vector3> ChannelHovered;
+    public event Action DeleteSelectedChannelRequested;
+
     public MouldSceneManager(IGeometryEngine engine)
     {
         _engine = engine;
+        _grid = SceneHelpers.GenerateGrid();
     }
 
     public Result UpdateWorkspace(Workspace workspace)
     {
         Workspace = workspace;
 
+        if (_targetMeshId != Guid.Empty)
+            VisualRemovedById?.Invoke(_targetMeshId);
+
+        var activeMeshResult = Workspace.GetActiveMesh();
+        if (activeMeshResult.IsFailure)
+            return activeMeshResult.Error;
+
+        TargetMesh = activeMeshResult.Value;
+
+        var geometryResult = TargetMesh.ToHelixMesh(_engine);
+        if (geometryResult.IsFailure)
+            return geometryResult.Error;
+
+        var model = new MeshGeometryModel3D
+        {
+            Geometry = geometryResult.Value,
+            Material = _targetSkin,
+        };
+
+        _targetMeshId = model.GUID;
+        VisualAddedOrUpdated?.Invoke(model);
+
         return Result.Success();
-    }
-
-    public Result UpdateChannels(IEnumerable<IAirChannel> channels)
-    {
-
-        return Result.Success();
-    }
-
-    public void UpdatePreviewChannel(IAirChannel channel)
-    {
-        Vector3 point = Vector3.Zero;
-        PreviewChannel = channel;
     }
 
     public Result UpdateMould(MouldDefinition mouldDefinition)
     {
-        MouldDefinition = mouldDefinition;
+        if (_mouldModel is not null)
+        {
+            VisualRemovedById?.Invoke(_mouldModel.GUID);
+            _mouldModel = null;
+        }
+
+        if (TargetMesh is null)
+            return Result.Success();
+
+        var generateResult = mouldDefinition.Generate(_engine, TargetMesh);
+        if (generateResult.IsFailure)
+            return Result.Success(); // Invalid parameters mid-drag; just skip the preview silently.
+
+        using var mouldMesh = generateResult.Value;
+
+        var geometryResult = mouldMesh.ToHelixMesh(_engine);
+        if (geometryResult.IsFailure)
+            return Result.Success();
+
+        _mouldModel = new MeshGeometryModel3D
+        {
+            Geometry = geometryResult.Value,
+            Material = _mouldSkin,
+            // The mould shell encloses the target mesh; picking must fall through to the
+            // mesh underneath so hovering/clicking on it can place air channels.
+            IsHitTestVisible = false,
+            Visibility = _mouldHiddenForHover ? Visibility.Hidden : Visibility.Visible,
+        };
+
+        VisualAddedOrUpdated?.Invoke(_mouldModel);
 
         return Result.Success();
     }
 
-    public void OnActivated() { }
+    private void SetMouldHiddenForHover(bool hidden)
+    {
+        if (_mouldHiddenForHover == hidden)
+            return;
+
+        _mouldHiddenForHover = hidden;
+
+        if (_mouldModel is null)
+            return;
+
+        _mouldModel.Visibility = hidden ? Visibility.Collapsed : Visibility.Visible;
+        VisualAddedOrUpdated?.Invoke(_mouldModel);
+    }
+
+    public Result UpdateChannels(IReadOnlyList<AirChannelModel> channels)
+    {
+        foreach (var visualId in _channelVisualToModelId.Keys.ToList())
+            VisualRemovedById?.Invoke(visualId);
+
+        _channelVisualToModelId.Clear();
+        _channelModelToVisualId.Clear();
+        Channels = channels;
+
+        foreach (var channel in Channels)
+        {
+            var generateResult = channel.DomainModel.Generate(_engine, AirChannelRenderMode.Full);
+            if (generateResult.IsFailure)
+                continue;
+
+            using var channelMesh = generateResult.Value;
+            var geometryResult = channelMesh.ToHelixMesh(_engine);
+            if (geometryResult.IsFailure)
+                continue;
+
+            var model = new MeshGeometryModel3D
+            {
+                Geometry = geometryResult.Value,
+                Material = channel.Id == _selectedChannelId ? _selectedChannelSkin : _channelSkin,
+                CullMode = SharpDX.Direct3D11.CullMode.Back,
+            };
+
+            _channelVisualToModelId[model.GUID] = channel.Id;
+            _channelModelToVisualId[channel.Id] = model.GUID;
+            VisualAddedOrUpdated?.Invoke(model);
+        }
+
+        return Result.Success();
+    }
+
+    public void SelectChannel(Guid channelId)
+    {
+        _selectedChannelId = channelId;
+        UpdateChannels(Channels);
+        ChannelSelected?.Invoke(channelId);
+    }
+
+    public void UpdatePreviewChannel(IAirChannel channel)
+    {
+        PreviewChannel = channel;
+        RenderPreviewChannel();
+    }
+
+    private void RenderPreviewChannel()
+    {
+        if (_previewChannelId != Guid.Empty)
+        {
+            VisualRemovedById?.Invoke(_previewChannelId);
+            _previewChannelId = Guid.Empty;
+        }
+
+        if (PreviewChannel is null || !_mouseOverTarget)
+            return;
+
+        var generateResult = PreviewChannel.Generate(_engine, AirChannelRenderMode.Full);
+        if (generateResult.IsFailure)
+            return;
+
+        using var previewMesh = generateResult.Value;
+        var geometryResult = previewMesh.ToHelixMesh(_engine);
+        if (geometryResult.IsFailure)
+            return;
+
+        var model = new MeshGeometryModel3D
+        {
+            Geometry = geometryResult.Value,
+            Material = _previewChannelSkin,
+            IsHitTestVisible = false,
+            CullMode = SharpDX.Direct3D11.CullMode.Back,
+        };
+
+        _previewChannelId = model.GUID;
+        VisualAddedOrUpdated?.Invoke(model);
+    }
+
+    public void OnActivated()
+    {
+        VisualsCleared?.Invoke();
+        VisualAddedOrUpdated?.Invoke(_grid);
+    }
 
     public void OnDeactivated() { }
 
-    public bool OnKeyDown(Key key) => false;
+    public bool OnKeyDown(Key key)
+    {
+        if (key == Key.Delete && _selectedChannelId != Guid.Empty)
+        {
+            DeleteSelectedChannelRequested?.Invoke();
+            return true;
+        }
+
+        return false;
+    }
 
     public bool OnKeyUp(Key key) => false;
 
-    public bool OnMouseDown(MouseDown3DEventArgs eventArgs) => false;
+    public bool OnMouseDown(MouseDown3DEventArgs eventArgs)
+    {
+        // Right/middle click drive camera rotate/pan gestures; only place or select on left click.
+        if (eventArgs.OriginalInputEventArgs is not System.Windows.Input.MouseButtonEventArgs { ChangedButton: System.Windows.Input.MouseButton.Left })
+            return false;
 
-    public bool OnMouseMove(MouseMove3DEventArgs eventArgs) => false;
+        var hit = eventArgs.HitTestResult;
+
+        if (hit?.ModelHit is not MeshGeometryModel3D meshHit)
+        {
+            // Missed everything: deselect rather than leaving a stale selection highlighted.
+            SelectChannel(Guid.Empty);
+            return false;
+        }
+
+        if (meshHit.GUID == _targetMeshId)
+        {
+            var point = new Vector3(hit.PointHit.X, hit.PointHit.Y, hit.PointHit.Z);
+            var normal = new Vector3(hit.NormalAtHit.X, hit.NormalAtHit.Y, hit.NormalAtHit.Z);
+
+            ChannelPlaced?.Invoke(point, normal);
+            return true;
+        }
+
+        if (_channelVisualToModelId.TryGetValue(meshHit.GUID, out var channelId))
+        {
+            SelectChannel(channelId);
+            return true;
+        }
+
+        // Hit something unrelated (e.g. the grid): also clear the selection.
+        SelectChannel(Guid.Empty);
+        return false;
+    }
+
+    public bool OnMouseMove(HitTestResult? hit)
+    {
+        bool overTarget = hit?.ModelHit is MeshGeometryModel3D meshHit && meshHit.GUID == _targetMeshId;
+
+        SetMouldHiddenForHover(overTarget);
+        _mouseOverTarget = overTarget;
+
+        if (!overTarget)
+        {
+            RenderPreviewChannel(); // hides the marker left over from the last hover
+            return false;
+        }
+
+        var point = new Vector3(hit.PointHit.X, hit.PointHit.Y, hit.PointHit.Z);
+        var normal = new Vector3(hit.NormalAtHit.X, hit.NormalAtHit.Y, hit.NormalAtHit.Z);
+
+        // Total length depends on the mould's bounds and this point's own Z, so the
+        // preview is rebuilt in full via ChannelHovered rather than just repositioned -
+        // a plain SetPreview would move the start point but leave a stale total length.
+        ChannelHovered?.Invoke(point, normal);
+
+        return true;
+    }
 
     public bool OnMouseUp(MouseUp3DEventArgs eventArgs) => false;
 }

--- a/src/Fabolus.Wpf/Features/Moulding/MouldSceneManager.cs
+++ b/src/Fabolus.Wpf/Features/Moulding/MouldSceneManager.cs
@@ -1,0 +1,69 @@
+﻿using Fabolus.Core.Common;
+using Fabolus.Core.Features.AirChannels;
+using Fabolus.Core.Features.Moulds;
+using Fabolus.Core.Geometry;
+using Fabolus.Wpf.Features.Viewport;
+using HelixToolkit.Wpf.SharpDX;
+using System.Numerics;
+using System.Windows.Input;
+
+namespace Fabolus.Wpf.Features.Moulding;
+
+public class MouldSceneManager : ISceneManager
+{
+    private readonly IGeometryEngine _engine;
+
+    private Workspace Workspace { get; set; }
+    private IReadOnlyList<IAirChannel> Channels { get; set; } = [];
+    private IAirChannel PreviewChannel { get; set; }
+    private MouldDefinition MouldDefinition { get; set; }
+
+    public event Action<Element3D> VisualAddedOrUpdated;
+    public event Action<Guid> VisualRemovedById;
+    public event Action VisualsCleared;
+
+    public MouldSceneManager(IGeometryEngine engine)
+    {
+        _engine = engine;
+    }
+
+    public Result UpdateWorkspace(Workspace workspace)
+    {
+        Workspace = workspace;
+
+        return Result.Success();
+    }
+
+    public Result UpdateChannels(IEnumerable<IAirChannel> channels)
+    {
+
+        return Result.Success();
+    }
+
+    public void UpdatePreviewChannel(IAirChannel channel)
+    {
+        Vector3 point = Vector3.Zero;
+        PreviewChannel = channel;
+    }
+
+    public Result UpdateMould(MouldDefinition mouldDefinition)
+    {
+        MouldDefinition = mouldDefinition;
+
+        return Result.Success();
+    }
+
+    public void OnActivated() { }
+
+    public void OnDeactivated() { }
+
+    public bool OnKeyDown(Key key) => false;
+
+    public bool OnKeyUp(Key key) => false;
+
+    public bool OnMouseDown(MouseDown3DEventArgs eventArgs) => false;
+
+    public bool OnMouseMove(MouseMove3DEventArgs eventArgs) => false;
+
+    public bool OnMouseUp(MouseUp3DEventArgs eventArgs) => false;
+}

--- a/src/Fabolus.Wpf/Features/Moulding/MouldView.xaml
+++ b/src/Fabolus.Wpf/Features/Moulding/MouldView.xaml
@@ -1,0 +1,76 @@
+﻿<UserControl x:Class="Fabolus.Wpf.Features.Moulding.MouldView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Fabolus.Wpf.Features.Moulding"
+             xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+             mc:Ignorable="d" 
+             d:DataContext="{d:DesignInstance local:MouldViewModel, IsDesignTimeCreatable=True}"
+             d:DesignHeight="620" d:DesignWidth="260"
+             Background="Transparent">
+    <UserControl.Resources>
+        
+    <!-- Field caption above each control -->
+    <Style x:Key="FieldLabel" TargetType="TextBlock">
+        <Setter Property="FontFamily" Value="{StaticResource Font.Sans}" />
+        <Setter Property="FontSize" Value="12" />
+        <Setter Property="FontWeight" Value="Medium" />
+        <Setter Property="Foreground" Value="{DynamicResource Brush.Text.Secondary}" />
+    </Style>
+
+    <!-- Helper caption (sub-label under a control) -->
+    <Style x:Key="FieldHint" TargetType="TextBlock">
+        <Setter Property="FontFamily" Value="{StaticResource Font.Sans}" />
+        <Setter Property="FontSize" Value="10.5" />
+        <Setter Property="Foreground" Value="{DynamicResource Brush.Text.Muted}" />
+        <Setter Property="TextWrapping" Value="Wrap" />
+    </Style>
+
+    <!-- Accordion section header: icon + title (+ optional trailing content) -->
+    <Style x:Key="SectionExpander" TargetType="Expander">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="{DynamicResource Brush.Divider}" />
+        <Setter Property="BorderThickness" Value="0,0,0,1" />
+        <Setter Property="Padding" Value="0" />
+    </Style>
+
+    </UserControl.Resources>
+
+    <!-- Tool-rail shell -->
+    <Border Style="{StaticResource ToolRail}">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <!-- scrolling accordion -->
+                <RowDefinition Height="Auto" />
+                <!-- pinned primary action -->
+            </Grid.RowDefinitions>
+
+            <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled" Padding="0">
+                <StackPanel>
+                    <local:ChannelsControl DataContext="{Binding}" />
+
+                    <local:MouldControl DataContext="{Binding}" />
+
+                </StackPanel>
+            </ScrollViewer>
+
+            <!-- Pinned primary action -->
+            <Button Grid.Row="1" Command="{Binding GenerateMouldCommand}"
+                    Style="{StaticResource Button.Primary}" HorizontalAlignment="Stretch"
+                    Margin="16,12,16,16">
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                    <Viewbox Width="15" Height="15" Margin="0,0,8,0">
+                        <Path Data="{StaticResource Icon.Mould}"
+                              Stroke="{DynamicResource Brush.Text.OnAccent}" StrokeThickness="1.6" Fill="{x:Null}"
+                              StrokeStartLineCap="Round" StrokeEndLineCap="Round" StrokeLineJoin="Round" />
+                    </Viewbox>
+                    <TextBlock Text="Generate Mould" VerticalAlignment="Center" />
+                </StackPanel>
+            </Button>
+
+        </Grid>
+    </Border>
+</UserControl>

--- a/src/Fabolus.Wpf/Features/Moulding/MouldView.xaml.cs
+++ b/src/Fabolus.Wpf/Features/Moulding/MouldView.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace Fabolus.Wpf.Features.Moulding
+{
+    /// <summary>
+    /// Interaction logic for MouldView.xaml
+    /// </summary>
+    public partial class MouldView : UserControl
+    {
+        public MouldView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Fabolus.Wpf/Features/Moulding/MouldViewModel.cs
+++ b/src/Fabolus.Wpf/Features/Moulding/MouldViewModel.cs
@@ -6,9 +6,7 @@ using Fabolus.Core.Features.Moulds;
 using Fabolus.Core.Geometry;
 using Fabolus.Wpf.Common;
 using Fabolus.Wpf.Features.Viewport;
-using System.Collections.ObjectModel;
 using System.Numerics;
-using static MR.Features.Const_MeasureResult;
 
 namespace Fabolus.Wpf.Features.Moulding;
 
@@ -18,25 +16,161 @@ public partial class MouldViewModel : ObservableObject, IViewState
     private readonly IAlertDialog _alert;
     private readonly IGeometryEngine _engine;
     private readonly MouldSceneManager _sceneManager;
+    private readonly GenerateMould _generateMouldFeature;
 
     private Workspace Workspace { get; set; }
 
-    public ObservableCollection<IAirChannel> Channels { get; set; } = [];
-    private IAirChannel PreviewChannel { get; set; }
-    [ObservableProperty] private IAirChannel? _selectedchannel;
+    private List<AirChannelModel> Channels { get; set; } = [];
+    public int ChannelCount => Channels.Count;
 
-    private AirChannelType _channelType { get; set; } = AirChannelType.Straight;
+    // Last point/normal the mouse hovered on the target mesh, so switching channel type
+    // rebuilds the preview in place instead of resetting it to the origin.
+    private Vector3 _lastHoverPoint = Vector3.Zero;
+    private Vector3 _lastHoverNormal = Vector3.UnitZ;
 
-    [ObservableProperty] private float _tipDiameter;
-    [ObservableProperty] private float _tipLength;
-    [ObservableProperty] private float _tipDepth;
-    [ObservableProperty] private float _channelDiameter;
+    // Selection lives in the scene manager (left-clicking a placed channel marker selects
+    // it there); this mirrors that selection so the parameter panel can edit it.
+    [ObservableProperty] private Guid _selectedChannelId = Guid.Empty;
 
-    public bool IsStraightType => _channelType == AirChannelType.Straight;
-    public bool IsAngledType => _channelType == AirChannelType.Angled;
-    public bool IsPathType => _channelType == AirChannelType.Painted;
+    // True while the parameter fields are being populated *from* the selected channel,
+    // so those assignments don't immediately turn around and rewrite the channel.
+    private bool _syncingSelection;
 
-    private MouldDefinition MouldDefinition { get; set; }
+    partial void OnSelectedChannelIdChanged(Guid value)
+    {
+        var channel = value == Guid.Empty ? null : Channels.FirstOrDefault(c => c.Id == value);
+        if (channel is null) return;
+
+        _syncingSelection = true;
+        ChannelType = channel.Type;
+        TipLength = (float)channel.TipLength;
+        var penetrationDepth = ExtractPenetrationDepth(channel.DomainModel);
+        if (penetrationDepth.HasValue)
+            TipDepth = penetrationDepth.Value;
+        // Channel diameter first: tip diameter is clamped against it, so setting this
+        // order avoids a transient clamp against a stale value from the prior selection.
+        ChannelDiameter = (float)channel.ChannelDiameter;
+        TipDiameter = (float)channel.TipDiameter;
+        _syncingSelection = false;
+    }
+
+    private static float? ExtractPenetrationDepth(IAirChannel domainModel) => domainModel switch
+    {
+        StraightAirChannel s => s.PenetrationDepth,
+        AngledAirChannel a => a.PenetrationDepth,
+        PaintedAirChannel p => p.PenetrationDepth,
+        _ => null
+    };
+
+    [ObservableProperty] private AirChannelType _channelType = AirChannelType.Straight;
+
+    partial void OnChannelTypeChanged(AirChannelType value)
+    {
+        OnPropertyChanged(nameof(IsStraightType));
+        OnPropertyChanged(nameof(IsAngledType));
+        OnPropertyChanged(nameof(IsPathType));
+        OnPropertyChanged(nameof(ChannelTypeDescription));
+
+        ApplyChannelEdits();
+    }
+
+    [ObservableProperty] private float _tipDiameter = 3.0f;
+    [ObservableProperty] private float _tipLength = 3.0f;
+    [ObservableProperty] private float _tipDepth = 1.0f;
+    [ObservableProperty] private float _channelDiameter = 5.0f;
+
+    partial void OnTipDiameterChanged(float value)
+    {
+        // The tip tapers down to the channel body, so it can never be wider than it.
+        if (!_syncingSelection && value > ChannelDiameter)
+        {
+            TipDiameter = ChannelDiameter; // re-enters this handler with a valid value
+            return;
+        }
+
+        ApplyChannelEdits();
+    }
+
+    partial void OnTipLengthChanged(float value) => ApplyChannelEdits();
+    partial void OnTipDepthChanged(float value) => ApplyChannelEdits();
+
+    partial void OnChannelDiameterChanged(float value)
+    {
+        if (!_syncingSelection && TipDiameter > value)
+        {
+            TipDiameter = value; // re-enters OnTipDiameterChanged, which applies the edits
+            return;
+        }
+
+        ApplyChannelEdits();
+    }
+
+    // The hover preview always tracks current parameters (it's what the next click will
+    // place); if a channel is also selected, it gets updated in place too.
+    private void ApplyChannelEdits()
+    {
+        if (_syncingSelection) return;
+
+        UpdatePreviewChannel();
+
+        if (SelectedChannelId != Guid.Empty)
+            UpdateSelectedChannel();
+    }
+
+    private void UpdateSelectedChannel()
+    {
+        var existing = Channels.FirstOrDefault(c => c.Id == SelectedChannelId);
+        if (existing is null) return;
+
+        var position = existing.Position;
+        var direction = existing.Direction;
+        var totalLength = ComputeTotalLength(position.Z);
+
+        IAirChannel domainModel = ChannelType switch
+        {
+            AirChannelType.Angled => new AngledAirChannel(position, direction, TipLength, totalLength, TipDiameter, ChannelDiameter / 2f, TipDepth),
+            AirChannelType.Painted => new PaintedAirChannel([position], ChannelDiameter / 2f, totalLength, TipDepth),
+            _ => new StraightAirChannel(position, TipLength, totalLength, TipDiameter, ChannelDiameter, TipDepth)
+        };
+
+        var updated = existing with
+        {
+            Type = ChannelType,
+            TipDiameter = TipDiameter,
+            ChannelDiameter = ChannelDiameter,
+            TipLength = TipLength,
+            DomainModel = domainModel
+        };
+
+        Channels = Channels.Select(c => c.Id == SelectedChannelId ? updated : c).ToList();
+
+        _sceneManager.UpdateChannels(Channels);
+        UpdateMould();
+    }
+
+    public bool IsStraightType => ChannelType == AirChannelType.Straight;
+    public bool IsAngledType => ChannelType == AirChannelType.Angled;
+    public bool IsPathType => ChannelType == AirChannelType.Painted;
+
+    public string ChannelTypeDescription => ChannelType switch
+    {
+        AirChannelType.Straight => "Drops straight down from the click point.",
+        AirChannelType.Angled => "Follows the surface normal at the click point.",
+        AirChannelType.Painted => "Traces a path painted across the surface.",
+        _ => string.Empty
+    };
+
+    public IReadOnlyList<MouldShapeType> MouldShapeTypes { get; } = Enum.GetValues<MouldShapeType>();
+
+    [ObservableProperty] private MouldShapeType _selectedMouldType = MouldShapeType.Concave;
+    // "Wall thickness" maps to the XY offset around the mesh; "Base height" maps to the
+    // vertical offset below/above the mesh bounds (both ends share the one slider).
+    [ObservableProperty] private double _wallThickness = 2.0;
+    [ObservableProperty] private double _baseHeight = 5.0;
+
+    partial void OnSelectedMouldTypeChanged(MouldShapeType value) => UpdateMould();
+    partial void OnWallThicknessChanged(double value) => UpdateMould();
+    partial void OnBaseHeightChanged(double value) => UpdateMould();
 
     public ISceneManager SceneManager => _sceneManager;
 
@@ -47,7 +181,17 @@ public partial class MouldViewModel : ObservableObject, IViewState
         _alert = alert;
         _engine = engine;
 
+        _generateMouldFeature = new GenerateMould(_engine);
         _sceneManager = new MouldSceneManager(_engine);
+        _sceneManager.ChannelPlaced += OnChannelPlaced;
+        _sceneManager.ChannelSelected += id => SelectedChannelId = id;
+        _sceneManager.ChannelHovered += (point, normal) =>
+        {
+            _lastHoverPoint = point;
+            _lastHoverNormal = normal;
+            UpdatePreviewChannel(); // rebuilds so the total length tracks this point's Z
+        };
+        _sceneManager.DeleteSelectedChannelRequested += DeleteSelectedChannel;
     }
 
     public void Activate(Workspace workspace)
@@ -59,50 +203,120 @@ public partial class MouldViewModel : ObservableObject, IViewState
             return;
 
         IMesh mesh = activeMeshResult.Value;
-        var channelsResult = mesh.Metadata.AirChannels();
-
-        Channels.Clear();
-        if (channelsResult.HasValue) {
-            foreach(var channel in channelsResult.Value)
-                Channels.Add(channel);
-        }
-
-        PreviewChannel = new StraightAirChannel(Vector3.Zero, 3.0f, 15.0f, 3.0f, 5.0f);
-        UpdateChannels();
-        _sceneManager.UpdatePreviewChannel(PreviewChannel);
 
         var mouldResult = mesh.Metadata.MouldDefinition();
-        MouldDefinition = mouldResult.HasValue
+        var mouldDefinition = mouldResult.HasValue
             ? mouldResult.Value
             : new ConcaveMouldDefinition();
 
-        UpdateMould();
+        SelectedChannelId = Guid.Empty;
+        Channels = mouldDefinition.AirChannels.ToList();
+        OnPropertyChanged(nameof(ChannelCount));
+
+        SelectedMouldType = mouldDefinition switch
+        {
+            ConvexMouldDefinition => MouldShapeType.Convex,
+            ContouredMouldDefinition => MouldShapeType.Contoured,
+            _ => MouldShapeType.Concave
+        };
+
+        (WallThickness, BaseHeight) = mouldDefinition switch
+        {
+            ConvexMouldDefinition c => (c.OffsetXY, c.OffsetBottom),
+            ConcaveMouldDefinition c => (c.OffsetXY, c.OffsetBottom),
+            ContouredMouldDefinition c => (c.OffsetXY, BaseHeight),
+            _ => (WallThickness, BaseHeight)
+        };
+
+        UpdatePreviewChannel();
 
         var result = _sceneManager.UpdateWorkspace(Workspace);
         if (result.IsFailure)
             _alert.ShowError(result.Error.Description);
+
+        _sceneManager.UpdateChannels(Channels);
+        UpdateMould();
     }
 
     public Workspace Deactivate() => Workspace;
 
-    private void UpdateChannels()
+    private MouldDefinition BuildMouldDefinition() => SelectedMouldType switch
     {
-        var result = _sceneManager.UpdateChannels(Channels);
+        MouldShapeType.Convex => new ConvexMouldDefinition(WallThickness, BaseHeight, BaseHeight) { AirChannels = Channels },
+        MouldShapeType.Contoured => new ContouredMouldDefinition(WallThickness) { AirChannels = Channels },
+        _ => new ConcaveMouldDefinition(WallThickness, BaseHeight, BaseHeight) { AirChannels = Channels }
+    };
+
+    private void UpdateMould()
+    {
+        var result = _sceneManager.UpdateMould(BuildMouldDefinition());
         if (result.IsFailure)
             _alert.ShowError(result.Error.Description);
     }
 
-    private void UpdateMould()
+    // The channel must vent above the mould, not stay sealed inside it: its top always
+    // ends 2.0mm above the mould's bounding box, regardless of where its base is placed.
+    private const float MouldClearance = 2.0f;
+
+    private float ComputeTotalLength(float startZ)
     {
-        var result = _sceneManager.UpdateMould(MouldDefinition);
-        if (result.IsFailure)
-            _alert.ShowError(result.Error.Description);
+        var meshResult = Workspace.GetActiveMesh();
+        if (meshResult.IsFailure)
+            return TipLength;
+
+        var statsResult = _engine.Evaluators.GetStatistics(meshResult.Value);
+        if (statsResult.IsFailure)
+            return TipLength;
+
+        var topOffset = SelectedMouldType == MouldShapeType.Contoured ? WallThickness : BaseHeight;
+        var mouldTopZ = statsResult.Value.MaxZ + topOffset;
+        var totalLength = (float)(mouldTopZ + MouldClearance) - startZ;
+
+        // Never let the total length come out shorter than the cone/tip itself.
+        return Math.Max(totalLength, TipLength);
+    }
+
+    private void UpdatePreviewChannel()
+    {
+        var point = _lastHoverPoint;
+        var normal = _lastHoverNormal;
+        var totalLength = ComputeTotalLength(point.Z);
+
+        IAirChannel preview = ChannelType switch
+        {
+            AirChannelType.Angled => new AngledAirChannel(point, normal, TipLength, totalLength, TipDiameter, ChannelDiameter / 2f, TipDepth),
+            AirChannelType.Painted => new PaintedAirChannel([point], ChannelDiameter / 2f, totalLength, TipDepth),
+            _ => new StraightAirChannel(point, TipLength, totalLength, TipDiameter, ChannelDiameter, TipDepth)
+        };
+
+        _sceneManager.UpdatePreviewChannel(preview);
+    }
+
+    private void OnChannelPlaced(Vector3 point, Vector3 normal)
+    {
+        var totalLength = ComputeTotalLength(point.Z);
+
+        IAirChannel domainModel = ChannelType switch
+        {
+            AirChannelType.Angled => new AngledAirChannel(point, normal, TipLength, totalLength, TipDiameter, ChannelDiameter / 2f, TipDepth),
+            AirChannelType.Painted => new PaintedAirChannel([point], ChannelDiameter / 2f, totalLength, TipDepth),
+            _ => new StraightAirChannel(point, TipLength, totalLength, TipDiameter, ChannelDiameter, TipDepth)
+        };
+
+        var channel = new AirChannelModel(Guid.NewGuid(), ChannelType, TipDiameter, ChannelDiameter, TipLength, domainModel);
+
+        Channels = [.. Channels, channel];
+        OnPropertyChanged(nameof(ChannelCount));
+
+        _sceneManager.UpdateChannels(Channels);
+        _sceneManager.SelectChannel(channel.Id);
+        UpdateMould();
     }
 
     [RelayCommand]
     public void SetChannelType(string channelType)
     {
-        _channelType = channelType switch
+        ChannelType = channelType switch
         {
             "Straight" => AirChannelType.Straight,
             "Angled" => AirChannelType.Angled,
@@ -110,5 +324,45 @@ public partial class MouldViewModel : ObservableObject, IViewState
             _ => throw new Exception($"{channelType} doesn't match any AirChannelType")
         };
     }
-}
 
+    [RelayCommand]
+    public void DeleteSelectedChannel()
+    {
+        if (SelectedChannelId == Guid.Empty) return;
+
+        Channels = Channels.Where(c => c.Id != SelectedChannelId).ToList();
+        OnPropertyChanged(nameof(ChannelCount));
+
+        _sceneManager.UpdateChannels(Channels);
+        _sceneManager.SelectChannel(Guid.Empty);
+        UpdateMould();
+    }
+
+    [RelayCommand]
+    public void ClearChannels()
+    {
+        Channels = [];
+        OnPropertyChanged(nameof(ChannelCount));
+
+        _sceneManager.UpdateChannels(Channels);
+        _sceneManager.SelectChannel(Guid.Empty);
+        UpdateMould();
+    }
+
+    [RelayCommand]
+    public void GenerateMould()
+    {
+        var mouldDefinition = BuildMouldDefinition();
+
+        var result = _generateMouldFeature.Execute(Workspace, Workspace.ActiveMeshId, mouldDefinition);
+        if (result.IsFailure)
+        {
+            _alert.ShowError(result.Error.Description);
+            return;
+        }
+
+        Workspace = result.Value;
+        _sceneManager.UpdateWorkspace(Workspace);
+        _messenger.Send(new WorkspaceChangedMessage(Workspace));
+    }
+}

--- a/src/Fabolus.Wpf/Features/Moulding/MouldViewModel.cs
+++ b/src/Fabolus.Wpf/Features/Moulding/MouldViewModel.cs
@@ -1,0 +1,114 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using Fabolus.Core.Features.AirChannels;
+using Fabolus.Core.Features.Moulds;
+using Fabolus.Core.Geometry;
+using Fabolus.Wpf.Common;
+using Fabolus.Wpf.Features.Viewport;
+using System.Collections.ObjectModel;
+using System.Numerics;
+using static MR.Features.Const_MeasureResult;
+
+namespace Fabolus.Wpf.Features.Moulding;
+
+public partial class MouldViewModel : ObservableObject, IViewState
+{
+    private readonly IMessenger _messenger;
+    private readonly IAlertDialog _alert;
+    private readonly IGeometryEngine _engine;
+    private readonly MouldSceneManager _sceneManager;
+
+    private Workspace Workspace { get; set; }
+
+    public ObservableCollection<IAirChannel> Channels { get; set; } = [];
+    private IAirChannel PreviewChannel { get; set; }
+    [ObservableProperty] private IAirChannel? _selectedchannel;
+
+    private AirChannelType _channelType { get; set; } = AirChannelType.Straight;
+
+    [ObservableProperty] private float _tipDiameter;
+    [ObservableProperty] private float _tipLength;
+    [ObservableProperty] private float _tipDepth;
+    [ObservableProperty] private float _channelDiameter;
+
+    public bool IsStraightType => _channelType == AirChannelType.Straight;
+    public bool IsAngledType => _channelType == AirChannelType.Angled;
+    public bool IsPathType => _channelType == AirChannelType.Painted;
+
+    private MouldDefinition MouldDefinition { get; set; }
+
+    public ISceneManager SceneManager => _sceneManager;
+
+    public MouldViewModel() : this(WeakReferenceMessenger.Default, new AlertDialog(), new GeometryMeshLib.GeometryEngine(new FileSystem())) { }
+    public MouldViewModel(IMessenger messenger, IAlertDialog alert, IGeometryEngine engine)
+    {
+        _messenger = messenger;
+        _alert = alert;
+        _engine = engine;
+
+        _sceneManager = new MouldSceneManager(_engine);
+    }
+
+    public void Activate(Workspace workspace)
+    {
+        Workspace = workspace;
+
+        var activeMeshResult = Workspace.GetActiveMesh();
+        if (activeMeshResult.IsFailure)
+            return;
+
+        IMesh mesh = activeMeshResult.Value;
+        var channelsResult = mesh.Metadata.AirChannels();
+
+        Channels.Clear();
+        if (channelsResult.HasValue) {
+            foreach(var channel in channelsResult.Value)
+                Channels.Add(channel);
+        }
+
+        PreviewChannel = new StraightAirChannel(Vector3.Zero, 3.0f, 15.0f, 3.0f, 5.0f);
+        UpdateChannels();
+        _sceneManager.UpdatePreviewChannel(PreviewChannel);
+
+        var mouldResult = mesh.Metadata.MouldDefinition();
+        MouldDefinition = mouldResult.HasValue
+            ? mouldResult.Value
+            : new ConcaveMouldDefinition();
+
+        UpdateMould();
+
+        var result = _sceneManager.UpdateWorkspace(Workspace);
+        if (result.IsFailure)
+            _alert.ShowError(result.Error.Description);
+    }
+
+    public Workspace Deactivate() => Workspace;
+
+    private void UpdateChannels()
+    {
+        var result = _sceneManager.UpdateChannels(Channels);
+        if (result.IsFailure)
+            _alert.ShowError(result.Error.Description);
+    }
+
+    private void UpdateMould()
+    {
+        var result = _sceneManager.UpdateMould(MouldDefinition);
+        if (result.IsFailure)
+            _alert.ShowError(result.Error.Description);
+    }
+
+    [RelayCommand]
+    public void SetChannelType(string channelType)
+    {
+        _channelType = channelType switch
+        {
+            "Straight" => AirChannelType.Straight,
+            "Angled" => AirChannelType.Angled,
+            "Path" => AirChannelType.Painted,
+            _ => throw new Exception($"{channelType} doesn't match any AirChannelType")
+        };
+    }
+}
+

--- a/src/Fabolus.Wpf/Features/Rotatation/RotateSceneManager.cs
+++ b/src/Fabolus.Wpf/Features/Rotatation/RotateSceneManager.cs
@@ -233,6 +233,6 @@ internal class RotateSceneManager : ISceneManager {
     public bool OnKeyDown(Key key) => false;
     public bool OnKeyUp(Key key) => false;
     public bool OnMouseDown(MouseDown3DEventArgs eventArgs) => false;
-    public bool OnMouseMove(MouseMove3DEventArgs eventArgs) => false;
+    public bool OnMouseMove(HelixToolkit.Wpf.SharpDX.HitTestResult? hit) => false;
     public bool OnMouseUp(MouseUp3DEventArgs eventArgs) => false;
 }

--- a/src/Fabolus.Wpf/Features/Smoothing/SmoothingSceneManager.cs
+++ b/src/Fabolus.Wpf/Features/Smoothing/SmoothingSceneManager.cs
@@ -163,7 +163,7 @@ public class SmoothingSceneManager : ISceneManager
 
     public bool OnMouseDown(MouseDown3DEventArgs eventArgs) => false;
 
-    public bool OnMouseMove(MouseMove3DEventArgs eventArgs) => false;
+    public bool OnMouseMove(HelixToolkit.Wpf.SharpDX.HitTestResult? hit) => false;
 
     public bool OnMouseUp(MouseUp3DEventArgs eventArgs) => false;
 

--- a/src/Fabolus.Wpf/Features/Viewport/ISceneManager.cs
+++ b/src/Fabolus.Wpf/Features/Viewport/ISceneManager.cs
@@ -18,6 +18,10 @@ public interface ISceneManager {
 
     bool OnMouseDown(MouseDown3DEventArgs eventArgs);
     bool OnMouseUp(MouseUp3DEventArgs eventArgs);
-    bool OnMouseMove(MouseMove3DEventArgs eventArgs);
+
+    // Plain (non-3D) mouse move, hit-tested manually by the caller. HelixToolkit's
+    // MouseMove3D routed event only fires while a mouse button is held, which breaks
+    // hover-based interactions (e.g. previewing/placing items without dragging).
+    bool OnMouseMove(HitTestResult? hit);
 
 }

--- a/src/Fabolus.Wpf/Features/Viewport/ViewportControl.xaml
+++ b/src/Fabolus.Wpf/Features/Viewport/ViewportControl.xaml
@@ -32,7 +32,7 @@
             ShowViewCube="False"
             
             MouseDown3D="MainViewport_MouseDown3D"
-            MouseMove3D="MainViewport_MouseMove3D"
+            MouseMove="MainViewport_MouseMove"
             MouseUp3D="MainViewport_MouseUp3D"
             KeyDown="MainViewport_KeyDown"
             KeyUp="MainViewport_KeyUp">

--- a/src/Fabolus.Wpf/Features/Viewport/ViewportControl.xaml.cs
+++ b/src/Fabolus.Wpf/Features/Viewport/ViewportControl.xaml.cs
@@ -97,10 +97,13 @@ public partial class ViewportControl : UserControl, IDisposable {
         // normal function
     }
 
-    private void MainViewport_MouseMove3D(object sender, RoutedEventArgs e) {
-        if (e is MouseMove3DEventArgs args) {
-            SceneManager?.OnMouseMove(args);
-        }
+    private void MainViewport_MouseMove(object sender, MouseEventArgs e) {
+        if (SceneManager is null) return;
+
+        var position = e.GetPosition(MainViewport);
+        var hits = MainViewport.FindHits(position);
+
+        SceneManager.OnMouseMove(hits.Count > 0 ? hits[0] : null);
     }
 
     private void MainViewport_MouseUp3D(object sender, RoutedEventArgs e) {


### PR DESCRIPTION
## Summary
- Wires up the scaffolded Moulding tool page (target mesh, live mould preview, air channel placement) to the existing `GenerateMould` Core feature and rendering pipeline.
- Air channels are placed and selected via left-click directly in the viewport, with a live hover preview and selection editing (no separate list UI).
- Enforces channel geometry constraints: tip diameter ≤ channel diameter, tip length 3–8mm, tip depth (penetration into the mesh) 0–2mm, and total length auto-computed so every channel vents 2mm above the current mould's bounding box.
- Adds `PenetrationDepth` to `StraightAirChannel`/`AngledAirChannel` (Core), replacing a hardcoded `-1.0f` offset, mirroring the existing `PaintedAirChannel` field.
- Moves `MouldShapeType` into `Fabolus.Core.Features.Moulds`.
- Fixes hover/mouse-move hit-testing (HelixToolkit's `MouseMove3D` only fires while a button is held) by switching to plain WPF `MouseMove` with manual hit-testing, propagated through `ISceneManager`.
- Fixes a black-viewport-background bug caused by `IsTransparent = true` on an opaque mould material triggering HelixToolkit's OIT render path.
- Removes the non-functional Draft angle / Split into 2 parts / Resolution controls from `MouldControl.xaml` (no backing Core support yet — left for a future pass).

## Test plan
- [x] `dotnet build src/Fabolus.Wpf/Fabolus.Wpf.csproj` succeeds with no new warnings
- [x] `dotnet test tests/Fabolus.Core.Tests` — AirChannels/Moulds suites pass; unrelated pre-existing STL-fixture failures unaffected
- [x] Manual: import a test mesh, switch to Mould tab, confirm live mould preview updates with wall thickness/base height/shape, click to place channels of each type, edit selected channel parameters, delete/clear, Generate Mould

🤖 Generated with [Claude Code](https://claude.com/claude-code)