### PR TITLE
Light the viewport and fix mesh and mould shading

### DIFF
--- a/src/Fabolus.Wpf/Common/Converters.cs
+++ b/src/Fabolus.Wpf/Common/Converters.cs
@@ -78,3 +78,52 @@ public class StringToBrushConverter : IValueConverter {
         return Binding.DoNothing;
     }
 }
+
+/// <summary>
+/// Turns a camera look direction into a light direction rotated off the view axis.
+///
+/// Pointing a DirectionalLight3D straight down Camera.LookDirection makes a headlight: the
+/// light vector is parallel to the view vector, so N.L peaks wherever a surface faces the
+/// camera and the model shades as a radial gradient regardless of its curvature. Rotating
+/// the light off the view axis is what makes a mould cavity, a crease or a dish read. The
+/// light stays camera-relative, so orbiting never leaves the model unlit.
+/// </summary>
+public class LightOffsetConverter : IValueConverter {
+
+    /// <summary>Degrees to swing the light left of the view axis. Negative swings right.</summary>
+    public double OffsetDegrees { get; set; } = 22.0;
+
+    /// <summary>Degrees to raise the light above the view axis. Negative lowers it.</summary>
+    public double ElevationDegrees { get; set; } = 16.0;
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) {
+        if (value is not System.Windows.Media.Media3D.Vector3D look || look.Length < 1e-6) {
+            return new System.Windows.Media.Media3D.Vector3D(-1, 1, -1); // camera not ready yet
+        }
+
+        look.Normalize();
+
+        // Viewport3DX.ModelUpDirection is +Z
+        var right = System.Windows.Media.Media3D.Vector3D.CrossProduct(
+            look, new System.Windows.Media.Media3D.Vector3D(0, 0, 1));
+        if (right.Length < 1e-6) {
+            right = new System.Windows.Media.Media3D.Vector3D(1, 0, 0); // looking straight up or down
+        }
+        right.Normalize();
+
+        var up = System.Windows.Media.Media3D.Vector3D.CrossProduct(right, look);
+        up.Normalize();
+
+        // DirectionalLight3D.Direction is the direction light travels, so a light sitting up
+        // and to the left of the camera travels right and down as it crosses the scene.
+        var direction = look
+            + right * Math.Tan(OffsetDegrees * Math.PI / 180.0)
+            - up * Math.Tan(ElevationDegrees * Math.PI / 180.0);
+
+        direction.Normalize();
+        return direction;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}

--- a/src/Fabolus.Wpf/Common/Helpers/MaterialsHelper.cs
+++ b/src/Fabolus.Wpf/Common/Helpers/MaterialsHelper.cs
@@ -4,6 +4,20 @@ using SharpDX;
 
 namespace Fabolus.Wpf.Common.Helpers;
 
+/// <summary>
+/// Viewport materials.
+///
+/// These are Phong rather than Diffuse deliberately. HelixToolkit's diffuse pass
+/// (psDiffuseMap.hlsl) never samples the scene lights - it fakes shading with
+/// clamp(0.5 + 0.5 * abs(dot(viewDir, normal)), 0, 1). The multiplier only spans 0.5 to
+/// 1.0, so a material caps out at half its own colour and every model lives in a quarter
+/// of the available tonal range; and because of the abs(), a surface shades identically
+/// whether it faces towards or away from the camera. On a mould that is the whole problem:
+/// the cavity wall and the outer shell you are looking through return the same value, so
+/// the shape being cast is unreadable.
+///
+/// The Phong pass needs actual lights, which is why ViewportControl.xaml declares them.
+/// </summary>
 public static class MaterialsHelper
 {
 
@@ -18,4 +32,52 @@ public static class MaterialsHelper
         };
     }
 
+    /// <summary>
+    /// Material for a scanned or mesh-processed surface: the target mesh, a mould, a split
+    /// region. Everything else - manipulators, air channel tubes, the grid - is generated
+    /// geometry whose smooth normals are correct and should not use this.
+    ///
+    /// Vertex normals reach the GPU from MeshLib's computePerVertNormals, an area-weighted
+    /// one-ring average with no crease threshold, and these meshes are full of real creases.
+    /// It is worse on moulds than on the boli: 9.7% of mould_test's triangle corners are
+    /// shaded with a normal more than 45 degrees off the facet they belong to (5.1% for the
+    /// boli), because a mould mixes 1000+ mm2 flat wall facets with sub-mm2 cavity facets.
+    /// At 1% of its vertices the largest incident face is over 24,000 times the area of the
+    /// smallest, so the area-weighted average there is effectively just the wall's normal.
+    /// The visible result is a gradient smeared across walls that are actually flat and
+    /// rounded-off box corners.
+    ///
+    /// EnableFlatShading makes the pixel shader recover the true facet normal from
+    /// screen-space derivatives, so flat walls read flat and creases stay sharp without any
+    /// geometry changing. It also fixes two-sided surfaces: cross(ddy(wp), ddx(wp)) has no
+    /// access to winding, so the normal always faces the camera and the far wall of a
+    /// transparent mould stays lit instead of going black.
+    /// </summary>
+    public static PhongMaterial CreateSurfaceMaterial(Color4 color, bool enableVertexColor = false) {
+        var material = CreateMaterial(color, enableVertexColor);
+        material.EnableFlatShading = true;
+        return material;
+    }
+
+}
+
+/// <summary>
+/// Colours carried over verbatim from the DiffuseMaterials entries these replaced, so
+/// nothing changes hue or transparency. The scRGB values are the arguments HelixToolkit
+/// passes to its own ToColor for the same named material.
+/// </summary>
+public static class SkinColours
+{
+    public static Color4 Gray => PhongMaterials.ToColor(0.254902, 0.254902, 0.254902);
+    public static Color4 LightGray => PhongMaterials.ToColor(0.682353, 0.682353, 0.682353);
+    public static Color4 Ruby => PhongMaterials.ToColor(0.61424, 0.04136, 0.04136, 0.55);
+    public static Color4 Emerald => PhongMaterials.ToColor(0.07568, 0.61424, 0.07568, 0.55);
+    public static Color4 Pearl => PhongMaterials.ToColor(1.0, 0.829, 0.829, 0.922);
+    public static Color4 Orange => PhongMaterials.ToColor(0.992157, 0.513726, 0.0);
+
+    // DiffuseMaterials took these straight from the named palette rather than via
+    // ToColor, so they are the raw byte colours, not scRGB conversions.
+    public static Color4 Green => new(0.0f, 0.501961f, 0.0f, 1.0f);       // 0,128,0
+    public static Color4 Red => new(1.0f, 0.0f, 0.0f, 1.0f);              // 255,0,0
+    public static Color4 SkyBlue => new(0.529412f, 0.807843f, 0.921569f, 1.0f); // 135,206,235
 }

--- a/src/Fabolus.Wpf/Common/Helpers/MaterialsHelper.cs
+++ b/src/Fabolus.Wpf/Common/Helpers/MaterialsHelper.cs
@@ -81,3 +81,41 @@ public static class SkinColours
     public static Color4 Red => new(1.0f, 0.0f, 0.0f, 1.0f);              // 255,0,0
     public static Color4 SkyBlue => new(0.529412f, 0.807843f, 0.921569f, 1.0f); // 135,206,235
 }
+
+/// <summary>
+/// Ready-made viewport skins. Use these rather than calling <see cref="MaterialsHelper"/>
+/// directly, so the flat-vs-smooth decision is made once, here, instead of at every site.
+///
+/// The split is by what the geometry IS, not what colour it is. Anything that came out of a
+/// scan or a mesh operation goes under <see cref="Surface"/>; anything the app generated
+/// itself goes under <see cref="Primitive"/>. See
+/// <see cref="MaterialsHelper.CreateSurfaceMaterial"/> for why that distinction matters.
+///
+/// Each property hands back a fresh instance. Cache it in a field if you are going to reuse
+/// it, rather than calling per frame.
+/// </summary>
+public static class Skins
+{
+    /// <summary>
+    /// Scanned or mesh-processed surfaces: the target mesh, a mould, a split region. Flat
+    /// shaded, because their vertex normals are averaged across real creases.
+    /// </summary>
+    public static class Surface
+    {
+        public static PhongMaterial Gray => MaterialsHelper.CreateSurfaceMaterial(SkinColours.Gray);
+        public static PhongMaterial Ruby => MaterialsHelper.CreateSurfaceMaterial(SkinColours.Ruby);
+        public static PhongMaterial Emerald => MaterialsHelper.CreateSurfaceMaterial(SkinColours.Emerald);
+        public static PhongMaterial Orange => MaterialsHelper.CreateSurfaceMaterial(SkinColours.Orange);
+        public static PhongMaterial SkyBlue => MaterialsHelper.CreateSurfaceMaterial(SkinColours.SkyBlue);
+    }
+
+    /// <summary>
+    /// Geometry the app generated: air channel tubes, manipulator handles, markers. Their
+    /// smooth normals are correct, so these are left smooth shaded.
+    /// </summary>
+    public static class Primitive
+    {
+        public static PhongMaterial Emerald => MaterialsHelper.CreateMaterial(SkinColours.Emerald);
+        public static PhongMaterial Pearl => MaterialsHelper.CreateMaterial(SkinColours.Pearl);
+    }
+}

--- a/src/Fabolus.Wpf/Features/CutSplit/CutSplitSceneManager.cs
+++ b/src/Fabolus.Wpf/Features/CutSplit/CutSplitSceneManager.cs
@@ -1,4 +1,4 @@
-using Fabolus.Core.Geometry;
+﻿using Fabolus.Core.Geometry;
 using Fabolus.Wpf.Common.Mesh;
 using Fabolus.Wpf.Features.Viewport;
 using HelixToolkit.Wpf.SharpDX;
@@ -6,14 +6,15 @@ using SharpDX;
 using System;
 using System.Windows.Input;
 using System.Windows.Media;
+using Fabolus.Wpf.Common.Helpers;
 
 namespace Fabolus.Wpf.Features.CutSplit;
 
 public class CutSplitSceneManager : ISceneManager
 {
     private readonly IGeometryEngine _engine;
-    private readonly Material _topSkin = DiffuseMaterials.SkyBlue;
-    private readonly Material _bottomSkin = DiffuseMaterials.Orange;
+    private readonly Material _topSkin = MaterialsHelper.CreateSurfaceMaterial(SkinColours.SkyBlue);
+    private readonly Material _bottomSkin = MaterialsHelper.CreateSurfaceMaterial(SkinColours.Orange);
 
     private readonly Element3D _grid;
     private CrossSectionMeshGeometryModel3D? _topModel;

--- a/src/Fabolus.Wpf/Features/CutSplit/CutSplitSceneManager.cs
+++ b/src/Fabolus.Wpf/Features/CutSplit/CutSplitSceneManager.cs
@@ -13,8 +13,8 @@ namespace Fabolus.Wpf.Features.CutSplit;
 public class CutSplitSceneManager : ISceneManager
 {
     private readonly IGeometryEngine _engine;
-    private readonly Material _topSkin = MaterialsHelper.CreateSurfaceMaterial(SkinColours.SkyBlue);
-    private readonly Material _bottomSkin = MaterialsHelper.CreateSurfaceMaterial(SkinColours.Orange);
+    private readonly Material _topSkin = Skins.Surface.SkyBlue;
+    private readonly Material _bottomSkin = Skins.Surface.Orange;
 
     private readonly Element3D _grid;
     private CrossSectionMeshGeometryModel3D? _topModel;

--- a/src/Fabolus.Wpf/Features/Export/ExportSceneManager.cs
+++ b/src/Fabolus.Wpf/Features/Export/ExportSceneManager.cs
@@ -57,7 +57,7 @@ internal class ExportSceneManager : ISceneManager {
         MeshGeometry3D geometry = mesh.ToHelixMesh(_engine).Value;
         var model = new MeshGeometryModel3D {
             Geometry = geometry,
-            Material = MaterialsHelper.CreateSurfaceMaterial(SkinColours.Gray),
+            Material = Skins.Surface.Gray,
         };
         _activeId = model.GUID;
 

--- a/src/Fabolus.Wpf/Features/Export/ExportSceneManager.cs
+++ b/src/Fabolus.Wpf/Features/Export/ExportSceneManager.cs
@@ -1,4 +1,4 @@
-using CommunityToolkit.Mvvm.Messaging;
+﻿using CommunityToolkit.Mvvm.Messaging;
 using Fabolus.Wpf.Features.AppPreferences;
 using Fabolus.Core.Geometry;
 using Fabolus.Wpf.Common.Mesh;
@@ -6,6 +6,7 @@ using Fabolus.Wpf.Features.Viewport;
 using HelixToolkit.Wpf.SharpDX;
 using System.Windows.Input;
 using System;
+using Fabolus.Wpf.Common.Helpers;
 
 namespace Fabolus.Wpf.Features.Export;
 
@@ -56,7 +57,7 @@ internal class ExportSceneManager : ISceneManager {
         MeshGeometry3D geometry = mesh.ToHelixMesh(_engine).Value;
         var model = new MeshGeometryModel3D {
             Geometry = geometry,
-            Material = DiffuseMaterials.Gray,
+            Material = MaterialsHelper.CreateSurfaceMaterial(SkinColours.Gray),
         };
         _activeId = model.GUID;
 

--- a/src/Fabolus.Wpf/Features/MeshManager/MeshManagerSceneManager.cs
+++ b/src/Fabolus.Wpf/Features/MeshManager/MeshManagerSceneManager.cs
@@ -56,7 +56,7 @@ internal class MeshManagerSceneManager : ISceneManager {
         MeshGeometry3D geometry = mesh.ToHelixMesh(_engine).Value;
         var model = new MeshGeometryModel3D {
             Geometry = geometry,
-            Material = MaterialsHelper.CreateSurfaceMaterial(SkinColours.Gray),
+            Material = Skins.Surface.Gray,
         };
         _activeId = model.GUID;
 

--- a/src/Fabolus.Wpf/Features/MeshManager/MeshManagerSceneManager.cs
+++ b/src/Fabolus.Wpf/Features/MeshManager/MeshManagerSceneManager.cs
@@ -1,10 +1,11 @@
-using CommunityToolkit.Mvvm.Messaging;
+﻿using CommunityToolkit.Mvvm.Messaging;
 using Fabolus.Core.Geometry;
 using Fabolus.Wpf.Common.Mesh;
 using Fabolus.Wpf.Features.AppPreferences;
 using Fabolus.Wpf.Features.Viewport;
 using HelixToolkit.Wpf.SharpDX;
 using System.Windows.Input;
+using Fabolus.Wpf.Common.Helpers;
 
 namespace Fabolus.Wpf.Features.MeshManager;
 
@@ -55,7 +56,7 @@ internal class MeshManagerSceneManager : ISceneManager {
         MeshGeometry3D geometry = mesh.ToHelixMesh(_engine).Value;
         var model = new MeshGeometryModel3D {
             Geometry = geometry,
-            Material = DiffuseMaterials.Gray,
+            Material = MaterialsHelper.CreateSurfaceMaterial(SkinColours.Gray),
         };
         _activeId = model.GUID;
 

--- a/src/Fabolus.Wpf/Features/Moulding/MouldSceneManager.cs
+++ b/src/Fabolus.Wpf/Features/Moulding/MouldSceneManager.cs
@@ -1,4 +1,4 @@
-using System.Numerics;
+﻿using System.Numerics;
 using System.Windows;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.Messaging;
@@ -10,6 +10,7 @@ using Fabolus.Core.Geometry;
 using Fabolus.Wpf.Common.Mesh;
 using Fabolus.Wpf.Features.Viewport;
 using HelixToolkit.Wpf.SharpDX;
+using Fabolus.Wpf.Common.Helpers;
 
 namespace Fabolus.Wpf.Features.Moulding;
 
@@ -18,14 +19,14 @@ public class MouldSceneManager : ISceneManager
     private readonly IGeometryEngine _engine;
     private Element3D _grid;
 
-    private readonly Material _targetSkin = DiffuseMaterials.Gray;
+    private readonly Material _targetSkin = MaterialsHelper.CreateSurfaceMaterial(SkinColours.Gray);
 
     // The mould is only ever shown as a live preview before generation.
-    private readonly Material _mouldSkin = DiffuseMaterials.Ruby;
+    private readonly Material _mouldSkin = MaterialsHelper.CreateSurfaceMaterial(SkinColours.Ruby);
 
-    private readonly Material _channelSkin = DiffuseMaterials.Emerald;
-    private readonly Material _selectedChannelSkin = DiffuseMaterials.Pearl;
-    private readonly Material _previewChannelSkin = DiffuseMaterials.Pearl;
+    private readonly Material _channelSkin = MaterialsHelper.CreateMaterial(SkinColours.Emerald);
+    private readonly Material _selectedChannelSkin = MaterialsHelper.CreateMaterial(SkinColours.Pearl);
+    private readonly Material _previewChannelSkin = MaterialsHelper.CreateMaterial(SkinColours.Pearl);
 
     private IMesh? TargetMesh { get; set; }
     private IReadOnlyList<AirChannelModel> Channels { get; set; } = [];

--- a/src/Fabolus.Wpf/Features/Moulding/MouldSceneManager.cs
+++ b/src/Fabolus.Wpf/Features/Moulding/MouldSceneManager.cs
@@ -19,14 +19,14 @@ public class MouldSceneManager : ISceneManager
     private readonly IGeometryEngine _engine;
     private Element3D _grid;
 
-    private readonly Material _targetSkin = MaterialsHelper.CreateSurfaceMaterial(SkinColours.Gray);
+    private readonly Material _targetSkin = Skins.Surface.Gray;
 
     // The mould is only ever shown as a live preview before generation.
-    private readonly Material _mouldSkin = MaterialsHelper.CreateSurfaceMaterial(SkinColours.Ruby);
+    private readonly Material _mouldSkin = Skins.Surface.Ruby;
 
-    private readonly Material _channelSkin = MaterialsHelper.CreateMaterial(SkinColours.Emerald);
-    private readonly Material _selectedChannelSkin = MaterialsHelper.CreateMaterial(SkinColours.Pearl);
-    private readonly Material _previewChannelSkin = MaterialsHelper.CreateMaterial(SkinColours.Pearl);
+    private readonly Material _channelSkin = Skins.Primitive.Emerald;
+    private readonly Material _selectedChannelSkin = Skins.Primitive.Pearl;
+    private readonly Material _previewChannelSkin = Skins.Primitive.Pearl;
 
     private IMesh? TargetMesh { get; set; }
     private IReadOnlyList<AirChannelModel> Channels { get; set; } = [];

--- a/src/Fabolus.Wpf/Features/Moulding/MouldSceneManager.cs
+++ b/src/Fabolus.Wpf/Features/Moulding/MouldSceneManager.cs
@@ -60,6 +60,9 @@ public class MouldSceneManager : ISceneManager
     private readonly Dictionary<Guid, Guid> _channelVisualToModelId = [];
     private readonly Dictionary<Guid, Guid> _channelModelToVisualId = [];
 
+    // Live channel visuals by channel id, so they can be updated without being re-added.
+    private readonly Dictionary<Guid, MeshGeometryModel3D> _channelVisuals = [];
+
     public event Action<Element3D> VisualAddedOrUpdated;
     public event Action<Guid> VisualRemovedById;
     public event Action VisualsCleared;
@@ -191,6 +194,7 @@ public class MouldSceneManager : ISceneManager
             VisualRemovedById?.Invoke(visualId);
         _channelVisualToModelId.Clear();
         _channelModelToVisualId.Clear();
+        _channelVisuals.Clear();
         Channels = [];
         _selectedChannelId = Guid.Empty;
 
@@ -220,14 +224,20 @@ public class MouldSceneManager : ISceneManager
         VisualAddedOrUpdated?.Invoke(_mouldModel);
     }
 
+    /// <summary>
+    /// Channel visuals are retained and mutated in place rather than torn down and rebuilt.
+    ///
+    /// A rebuilt visual gets a fresh GUID, and ViewportControl appends any GUID it has not
+    /// seen to the end of MainViewport.Items. That silently moves every channel behind the
+    /// mould in the scene order, and once it is behind the mould it stops drawing inside it -
+    /// only the length sticking out the far side survives. Updating in place keeps both the
+    /// GUIDs and the scene order stable.
+    /// </summary>
     public Result UpdateChannels(IReadOnlyList<AirChannelModel> channels)
     {
-        foreach (var visualId in _channelVisualToModelId.Keys.ToList())
-            VisualRemovedById?.Invoke(visualId);
-
-        _channelVisualToModelId.Clear();
-        _channelModelToVisualId.Clear();
         Channels = channels;
+
+        var stillPresent = new HashSet<Guid>();
 
         foreach (var channel in Channels)
         {
@@ -240,25 +250,57 @@ public class MouldSceneManager : ISceneManager
             if (geometryResult.IsFailure)
                 continue;
 
+            var material = channel.Id == _selectedChannelId ? _selectedChannelSkin : _channelSkin;
+            stillPresent.Add(channel.Id);
+
+            if (_channelVisuals.TryGetValue(channel.Id, out var existing))
+            {
+                existing.Geometry = geometryResult.Value;
+                existing.Material = material;
+                continue;
+            }
+
             var model = new MeshGeometryModel3D
             {
                 Geometry = geometryResult.Value,
-                Material = channel.Id == _selectedChannelId ? _selectedChannelSkin : _channelSkin,
+                Material = material,
                 CullMode = SharpDX.Direct3D11.CullMode.Back,
             };
 
+            _channelVisuals[channel.Id] = model;
             _channelVisualToModelId[model.GUID] = channel.Id;
             _channelModelToVisualId[channel.Id] = model.GUID;
             VisualAddedOrUpdated?.Invoke(model);
         }
 
+        // Only channels that are genuinely gone leave the scene.
+        foreach (var channelId in _channelVisuals.Keys.Where(id => !stillPresent.Contains(id)).ToList())
+            RemoveChannelVisual(channelId);
+
         return Result.Success();
+    }
+
+    private void RemoveChannelVisual(Guid channelId)
+    {
+        if (_channelModelToVisualId.TryGetValue(channelId, out var visualId))
+        {
+            VisualRemovedById?.Invoke(visualId);
+            _channelVisualToModelId.Remove(visualId);
+        }
+
+        _channelModelToVisualId.Remove(channelId);
+        _channelVisuals.Remove(channelId);
     }
 
     public void SelectChannel(Guid channelId)
     {
         _selectedChannelId = channelId;
-        UpdateChannels(Channels);
+
+        // Selection is only a highlight: recolour the live models rather than regenerating
+        // every channel's mesh through UpdateChannels.
+        foreach (var (id, model) in _channelVisuals)
+            model.Material = id == _selectedChannelId ? _selectedChannelSkin : _channelSkin;
+
         ChannelSelected?.Invoke(channelId);
     }
 

--- a/src/Fabolus.Wpf/Features/Smoothing/CuttingPlane.cs
+++ b/src/Fabolus.Wpf/Features/Smoothing/CuttingPlane.cs
@@ -8,7 +8,7 @@ public static class CuttingPlane
     public static Element3D Create(Action<double> onHeightChanged, Func<double> getMinZ = null, Func<double> getMaxZ = null) {
         var element = new UITranslateManipulator3D {
             Direction = SharpDX.Vector3.UnitZ,
-            Material = MaterialsHelper.CreateMaterial(SkinColours.Pearl),
+            Material = Skins.Primitive.Pearl,
             Offset = SharpDX.Vector3.Zero,
             Length = 10.0,
             Diameter = 5.0

--- a/src/Fabolus.Wpf/Features/Smoothing/CuttingPlane.cs
+++ b/src/Fabolus.Wpf/Features/Smoothing/CuttingPlane.cs
@@ -1,4 +1,5 @@
 ﻿using HelixToolkit.Wpf.SharpDX;
+using Fabolus.Wpf.Common.Helpers;
 
 namespace Fabolus.Wpf.Features.Smoothing;
 
@@ -7,7 +8,7 @@ public static class CuttingPlane
     public static Element3D Create(Action<double> onHeightChanged, Func<double> getMinZ = null, Func<double> getMaxZ = null) {
         var element = new UITranslateManipulator3D {
             Direction = SharpDX.Vector3.UnitZ,
-            Material = DiffuseMaterials.Pearl,
+            Material = MaterialsHelper.CreateMaterial(SkinColours.Pearl),
             Offset = SharpDX.Vector3.Zero,
             Length = 10.0,
             Diameter = 5.0

--- a/src/Fabolus.Wpf/Features/Smoothing/SmoothingSceneManager.cs
+++ b/src/Fabolus.Wpf/Features/Smoothing/SmoothingSceneManager.cs
@@ -1,4 +1,4 @@
-using System.Windows.Input;
+﻿using System.Windows.Input;
 using System.Windows.Media;
 using Fabolus.Core.Features.Smoothing;
 using Fabolus.Core.Geometry;
@@ -8,13 +8,14 @@ using HelixToolkit.Wpf.SharpDX;
 using SharpDX;
 using CommunityToolkit.Mvvm.Messaging;
 using Fabolus.Wpf.Features.AppPreferences;
+using Fabolus.Wpf.Common.Helpers;
 
 namespace Fabolus.Wpf.Features.Smoothing;
 
 public class SmoothingSceneManager : ISceneManager
 {
-    private readonly Material _rawSkin = DiffuseMaterials.SkyBlue;
-    private readonly Material _smoothSkin = DiffuseMaterials.Emerald;
+    private readonly Material _rawSkin = MaterialsHelper.CreateSurfaceMaterial(SkinColours.SkyBlue);
+    private readonly Material _smoothSkin = MaterialsHelper.CreateSurfaceMaterial(SkinColours.Emerald);
 
     private readonly IGeometryEngine _engine;
     private readonly IMessenger _messenger;

--- a/src/Fabolus.Wpf/Features/Smoothing/SmoothingSceneManager.cs
+++ b/src/Fabolus.Wpf/Features/Smoothing/SmoothingSceneManager.cs
@@ -14,8 +14,8 @@ namespace Fabolus.Wpf.Features.Smoothing;
 
 public class SmoothingSceneManager : ISceneManager
 {
-    private readonly Material _rawSkin = MaterialsHelper.CreateSurfaceMaterial(SkinColours.SkyBlue);
-    private readonly Material _smoothSkin = MaterialsHelper.CreateSurfaceMaterial(SkinColours.Emerald);
+    private readonly Material _rawSkin = Skins.Surface.SkyBlue;
+    private readonly Material _smoothSkin = Skins.Surface.Emerald;
 
     private readonly IGeometryEngine _engine;
     private readonly IMessenger _messenger;

--- a/src/Fabolus.Wpf/Features/Viewport/ViewportControl.xaml
+++ b/src/Fabolus.Wpf/Features/Viewport/ViewportControl.xaml
@@ -4,8 +4,16 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:hx="http://helix-toolkit.org/wpf/SharpDX"
-             mc:Ignorable="d" 
+             xmlns:conv="clr-namespace:Fabolus.Wpf.Common.Convert"
+             mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800">
+    <UserControl.Resources>
+        <!-- Offsets are deliberately modest. Swinging the key light much further off the view
+             axis leaves obliquely presented meshes almost unlit: at 30/25 a third of the ear
+             bolus falls below byte 60, versus 1.5% here, with no loss of form contrast. -->
+        <conv:LightOffsetConverter x:Key="KeyLightDirection" OffsetDegrees="22" ElevationDegrees="16" />
+        <conv:LightOffsetConverter x:Key="FillLightDirection" OffsetDegrees="-45" ElevationDegrees="-12" />
+    </UserControl.Resources>
     <Grid>
         <Grid>
             <Grid.Background>
@@ -50,6 +58,27 @@
                     <MouseBinding Command="hx:ViewportCommands.Pan"    Gesture="MiddleClick" />
                     <KeyBinding   Command="hx:ViewportCommands.ZoomExtents" Gesture="Control+E" />
                 </hx:Viewport3DX.InputBindings>
+
+                <!-- The scene had no lights at all. That worked only because every skin was a
+                     DiffuseMaterial, and HelixToolkit's diffuse pass ignores lights and fakes
+                     its own shading. Any Phong or PBR material rendered pure black.
+                     Ambient is high because MaterialsHelper sets AmbientColor to 0.3 * diffuse:
+                     at #4A4A52 the shadow side of a mesh drops below the background gradient on
+                     3.7% of its pixels, versus 0.3% here, and form contrast is no worse. -->
+                <hx:AmbientLight3D Color="#FF909099" />
+
+                <!-- Key light, held off the view axis so curvature reads. Pointed straight
+                     along LookDirection it would be a headlight, which flattens form under
+                     any material. -->
+                <hx:DirectionalLight3D
+                    Color="#FFFFFFFF"
+                    Direction="{Binding Camera.LookDirection, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource KeyLightDirection}, FallbackValue='-1,1,-1'}" />
+
+                <!-- Dim fill from the opposite side so surfaces turned away from the key light
+                     still show shape rather than dropping to flat ambient. -->
+                <hx:DirectionalLight3D
+                    Color="#FF90909C"
+                    Direction="{Binding Camera.LookDirection, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource FillLightDirection}, FallbackValue='1,-1,-1'}" />
 
             </hx:Viewport3DX>
         </Grid>

--- a/src/Fabolus.Wpf/Features/Viewport/ViewportControl.xaml.cs
+++ b/src/Fabolus.Wpf/Features/Viewport/ViewportControl.xaml.cs
@@ -17,8 +17,10 @@ public partial class ViewportControl : UserControl, IDisposable {
     public DefaultEffectsManager EffectsManager { get; }
 
     public ViewportControl() {
-        InitializeComponent();
-
+        // Set before InitializeComponent: Camera and EffectsManager are plain CLR properties
+        // with no change notification, so anything in the XAML bound to them - the viewport
+        // itself, and the light directions bound through Camera.LookDirection - resolves once
+        // and never recovers if it happens to resolve while they are still null.
         EffectsManager = new DefaultEffectsManager();
         Camera = new HelixToolkit.Wpf.SharpDX.PerspectiveCamera {
             Position = new Point3D(0, 0, 100),
@@ -26,6 +28,7 @@ public partial class ViewportControl : UserControl, IDisposable {
             UpDirection = new Vector3D(0, 1, 0)
         };
 
+        InitializeComponent();
     }
 
     public ISceneManager? SceneManager {
@@ -71,11 +74,14 @@ public partial class ViewportControl : UserControl, IDisposable {
     }));
 
     private void OnClearAllVisuals() => Dispatcher.BeginInvoke(new Action(() => {
+        // Remove only what the scene managers put here. MainViewport.Items also holds the
+        // lights declared in XAML, and Items.Clear() destroys those too - after the first
+        // scene change the scene has no lights at all and every Phong material renders black.
         foreach (var visual in _registry.Values) {
+            MainViewport.Items.Remove(visual);
             visual.Dispose();
         }
         _registry.Clear();
-        MainViewport.Items.Clear();
     }));
 
     private void OnRemoveVisualById(Guid id) => Dispatcher.BeginInvoke(new Action(() => {


### PR DESCRIPTION
Meshes rendered as flat, formless silhouettes with no sense of depth. On a mould it was worse: the cavity wall and the transparent shell in front of it came out the same tone, so the shape being cast was unreadable.

Three separate causes.

## 1. `DiffuseMaterial` is not a lit material

HelixToolkit's diffuse pass (`psDiffuseMap.hlsl`) never samples the scene lights. It fakes shading with:

```hlsl
float f = clamp(0.5 + 0.5 * abs(dot(dir, N)), 0, 1);
c.rgb *= f;
```

Two consequences. The multiplier only spans 0.5–1.0, so a material caps out at half its own colour and every model lives in about a quarter of the available tonal range. And the `abs()` discards facing, so a surface shades identically whether it points toward or away from the camera — concave and convex read the same.

Worth noting for anyone who suspected inverted normals: because of that `abs()`, a flipped normal renders *identically* to a correct one. The shader could not have shown it.

## 2. There were no lights in the scene

Not a dim rig — no `AmbientLight3D` or `DirectionalLight3D` anywhere in the XAML or the code. That worked only because the diffuse pass ignores lights, which made the material choice load-bearing: swapping materials without adding lights renders everything black. `MaterialsHelper.CreateMaterial`, which builds `PhongMaterial`s, was dead code with no callers.

`ViewportControl.xaml` now declares an ambient, a key and a fill light. All twelve skins move to `MaterialsHelper`. Colours are carried over verbatim from the `DiffuseMaterials` entries they replace, so nothing changes hue or transparency.

## 3. Vertex normals smooth away real geometry

They come from MeshLib's `computePerVertNormals`, an area-weighted one-ring average with no crease threshold, and these meshes are full of genuine hard edges.

| | Chin bolus | Ear bolus | mould_test | scalp_mould |
|---|---|---|---|---|
| corners shaded >45° off their own facet | 5.1% | 5.1% | **9.7%** | **8.7%** |
| max:min incident face area at a vertex (p99) | 119:1 | 114:1 | **24,063:1** | **11,588:1** |
| sliver triangles (aspect > 50) | 0.25% | 0.14% | 3.4% | 5.0% |

Moulds are the worst case because they mix 1000+ mm² flat wall facets with sub-mm² cavity facets. At 1% of mould vertices one incident face is over 24,000× the area of another, so the area-weighted average there is effectively just the wall's normal. The visible result is a false gradient smeared across walls that are genuinely flat, and rounded-off box corners.

`CreateSurfaceMaterial` enables `EnableFlatShading` for scanned and mesh-processed surfaces, so the shader recovers the true facet normal from screen-space derivatives. No geometry changes. Generated geometry — channel tubes, manipulator handles — keeps its smooth normals, which are correct for it.

This was tested rather than assumed: rendering moulds both ways, smooth normals put a visible false gradient and a specular streak across planar walls while flat shading keeps them flat with crisp edges. Flat shading is *more* justified on moulds than on the boli.

It also keeps two-sided surfaces lit. `cross(ddy(wp), ddx(wp))` has no access to winding, so the derived normal always faces the camera, and the far wall of a transparent mould stays visible instead of going black.

## Three things lighting the scene needed beyond declaring the lights

**`OnClearAllVisuals` was destroying the lights.** It called `MainViewport.Items.Clear()`, which empties the whole `Element3D` collection — the lights included, not just the meshes the scene managers added. Scene managers raise `VisualsCleared` on activation, so the lights died on the first scene change and every Phong material rendered pure black. `Items` and `_registry` are kept in sync, so it now removes exactly the registered visuals and leaves anything declared in XAML alone.

**Binding resolution order.** `Camera` and `EffectsManager` are plain CLR properties with no change notification and were assigned *after* `InitializeComponent`, so any XAML binding resolving early would see null and never recover. This already applied to the pre-existing `Camera` binding on the viewport. They are now assigned first.

**Binding fallbacks.** The light `Direction` bindings carry a `FallbackValue`, so a failed binding yields a usable direction rather than the default zero vector, which normalizes to NaN in the vertex shader.

## Light levels are measured, not guessed

Both values were picked by sweeping across the six sample boli and both mould meshes.

- **Key at 22°/16° off the view axis**, not 30°/25° — at 30/25 a third of the ear bolus falls below byte 60, versus 1.5% here, with no loss of form contrast.
- **Ambient `#909099`**, not `#4A4A52` — at the darker value 3.7% of a mesh's pixels sink below the background gradient, versus 0.3% here.

Net effect on the opaque grey skin across all eight meshes: median 114 → 148, tonal spread 14.2 → 25.2.

A pure headlight (`Direction` bound straight to `Camera.LookDirection`) puts L parallel to V and flattens curvature under any material, which is why `LightOffsetConverter` exists. The rig stays camera-relative, so orbiting never leaves a model unlit.

## Review notes

- **Not built or run by me.** I have no .NET SDK and WPF is Windows-only, so every API was verified against the HelixToolkit v2.25.0 sources rather than a compiler. The rendering has been confirmed visually in the running app on an equivalent tree.
- **This changes appearance on every page**, not just moulds — unavoidable, since no lights existed before.
- `VertColorMaterial` uses `ColorMaterialCore`, its own unlit pass, so the parting-direction heat map is unaffected by adding lights.
- **If the parting-split work later merges into `v1`**, `PartingSplitSceneManager` brings 7 more `DiffuseMaterials` sites that will need the same conversion. It does not exist on this base, so it is not covered here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Drwu41TWFEzjLgFJGnkQSA)_